### PR TITLE
修复 Windows 保留端口启动失败并整理构建产物

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
 - `electron-main.js`：macOS Electron 宿主，复用同一个 `manager.js` 服务和 `manager.html`。
 - `gen-icon.cs`、`icon/`、`assets/`：Windows ICO/圆角 PNG 与 macOS SVG/ICNS 资源。
 - `test/`：Node 内置测试，当前覆盖付费墙目标检测和官方升级逻辑。
-- `build-tray.bat`：编译 Windows C# 宿主。
+- `build-tray.bat`：编译 Windows C# 宿主，产物统一写入 `.build/windows/`。
 - `build-release.bat`：更新本机自用 Windows 包，必须保留已有 `data/`。
 - `build-public-release.bat/.ps1`：生成脱敏的 Windows Lite/Portable ZIP 和 SHA256。
 
@@ -78,7 +78,7 @@ npm run build:mac:universal
 
 ## 版本与发布注意事项
 
-- `package.json` 当前版本为 1.4.1。
+- `package.json` 当前版本为 1.4.2。
 - 创建下一次 Release 前必须统一 package、程序集、脚本文件名、README 和标签版本；
   不要上传版本号不一致的附件。
 - GitHub Release 是独立发布动作。代码合并不会自动替换旧 Release 附件。

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ release 版只有一个入口：`TypelessToolkit.exe`。
 - 默认窗口最多为 1440×880，并自动适应屏幕工作区；工具栏按常用操作和系统操作分组，在窄窗口中整组换行。
 - 点击窗口关闭按钮会收纳到托盘；双击托盘图标或再次双击 EXE 可恢复窗口。
 - 托盘右键→「退出」才会关闭窗口及由它启动的后端进程。
-- 修改源码后运行 `build-release.bat`，会重新生成单入口 release 包。
+- 修改源码后运行 `build-release.bat`，会重新生成单入口 release 包；Windows 编译中间产物统一放在 `.build/windows/`，不会散落到源码根目录。
 
 `build-release.bat` 用于更新本机自用包，会保留已有账号和快照。准备公开附件时必须运行
 `build-public-release.bat`，它会生成：
 
-- `TypelessToolkit-v1.4.1-win-x64-portable.zip`：内置经过 SHA256 校验的 Node.js 24.15.0
-- `TypelessToolkit-v1.4.1-win-x64-lite.zip`：使用系统 Node.js 22.12+
+- `TypelessToolkit-v1.4.2-win-x64-portable.zip`：内置经过 SHA256 校验的 Node.js 24.15.0
+- `TypelessToolkit-v1.4.2-win-x64-lite.zip`：使用系统 Node.js 22.12+
 
 两个公开包都会强制使用示例账号和空 `profiles/`，并分别输出 SHA256 文件。绝不能直接上传
 本机自用 release 目录。

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.4.1.0" name="YGTT.TypelessToolkit" />
+  <assemblyIdentity version="1.4.2.0" name="YGTT.TypelessToolkit" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/build-public-release.ps1
+++ b/build-public-release.ps1
@@ -1,9 +1,10 @@
 $ErrorActionPreference = 'Stop'
 
-$publicVersion = '1.4.1'
+$publicVersion = '1.4.2'
 $nodeVersion = '24.15.0'
 $nodeDist = "node-v$nodeVersion-win-x64"
 $sourceRoot = [IO.Path]::GetFullPath($PSScriptRoot)
+$windowsBuildRoot = [IO.Path]::GetFullPath((Join-Path $sourceRoot '.build\windows'))
 $releaseRoot = [IO.Path]::GetFullPath((Join-Path $sourceRoot '..\release'))
 $baseName = "TypelessToolkit-v$publicVersion-win-x64"
 $liteTarget = [IO.Path]::GetFullPath((Join-Path $releaseRoot "$baseName-lite"))
@@ -43,15 +44,16 @@ function Copy-PublicFiles([string]$target) {
   New-Item -ItemType Directory -Force -Path (Join-Path $target 'server\lib') | Out-Null
   New-Item -ItemType Directory -Force -Path (Join-Path $target 'data\profiles') | Out-Null
 
-  $rootFiles = @(
+  $desktopFiles = @(
     'TypelessToolkit.exe',
     'Microsoft.Web.WebView2.Core.dll',
     'Microsoft.Web.WebView2.WinForms.dll',
-    'WebView2Loader.dll',
-    'LICENSE',
-    'README.md'
+    'WebView2Loader.dll'
   )
-  foreach ($file in $rootFiles) {
+  foreach ($file in $desktopFiles) {
+    Copy-Item -LiteralPath (Join-Path $windowsBuildRoot $file) -Destination (Join-Path $target $file) -Force
+  }
+  foreach ($file in @('LICENSE', 'README.md')) {
     Copy-Item -LiteralPath (Join-Path $sourceRoot $file) -Destination (Join-Path $target $file) -Force
   }
   Copy-Item -LiteralPath (Join-Path $sourceRoot '.build\webview2\1.0.4078.44\LICENSE.txt') -Destination (Join-Path $target 'WEBVIEW2-LICENSE.txt') -Force

--- a/build-release.bat
+++ b/build-release.bat
@@ -7,17 +7,17 @@ cd /d "%~dp0"
 call build-tray.bat
 if errorlevel 1 exit /b 1
 
-set "RELEASE=..\release\TypelessToolkit-v1.4.1"
+set "RELEASE=..\release\TypelessToolkit-v1.4.2"
 if not exist "%RELEASE%" mkdir "%RELEASE%"
 if not exist "%RELEASE%\server" mkdir "%RELEASE%\server"
 if not exist "%RELEASE%\server\lib" mkdir "%RELEASE%\server\lib"
 if not exist "%RELEASE%\data" mkdir "%RELEASE%\data"
 
 echo [release] Copying desktop application...
-copy /Y TypelessToolkit.exe "%RELEASE%\TypelessToolkit.exe" >nul || exit /b 1
-copy /Y Microsoft.Web.WebView2.Core.dll "%RELEASE%\Microsoft.Web.WebView2.Core.dll" >nul || exit /b 1
-copy /Y Microsoft.Web.WebView2.WinForms.dll "%RELEASE%\Microsoft.Web.WebView2.WinForms.dll" >nul || exit /b 1
-copy /Y WebView2Loader.dll "%RELEASE%\WebView2Loader.dll" >nul || exit /b 1
+copy /Y ".build\windows\TypelessToolkit.exe" "%RELEASE%\TypelessToolkit.exe" >nul || exit /b 1
+copy /Y ".build\windows\Microsoft.Web.WebView2.Core.dll" "%RELEASE%\Microsoft.Web.WebView2.Core.dll" >nul || exit /b 1
+copy /Y ".build\windows\Microsoft.Web.WebView2.WinForms.dll" "%RELEASE%\Microsoft.Web.WebView2.WinForms.dll" >nul || exit /b 1
+copy /Y ".build\windows\WebView2Loader.dll" "%RELEASE%\WebView2Loader.dll" >nul || exit /b 1
 copy /Y ".build\webview2\1.0.4078.44\LICENSE.txt" "%RELEASE%\WEBVIEW2-LICENSE.txt" >nul || exit /b 1
 copy /Y icon\tray-icon.ico "%RELEASE%\tray-icon.ico" >nul || exit /b 1
 copy /Y icon\icon-rounded.png "%RELEASE%\icon.png" >nul || exit /b 1
@@ -31,7 +31,9 @@ copy /Y package.json "%RELEASE%\server\package.json" >nul || exit /b 1
 copy /Y package-lock.json "%RELEASE%\server\package-lock.json" >nul || exit /b 1
 copy /Y icon\icon-rounded.png "%RELEASE%\server\icon.png" >nul || exit /b 1
 xcopy /E /I /Y lib "%RELEASE%\server\lib" >nul || exit /b 1
-xcopy /E /I /Y node_modules "%RELEASE%\server\node_modules" >nul || exit /b 1
+if exist "%RELEASE%\server\node_modules" rmdir /S /Q "%RELEASE%\server\node_modules"
+call npm.cmd --prefix "%RELEASE%\server" ci --omit=dev --ignore-scripts --no-audit --no-fund
+if errorlevel 1 exit /b 1
 
 if not exist "%RELEASE%\data\config.json" copy /Y config.example.json "%RELEASE%\data\config.json" >nul
 copy /Y accounts.example.json "%RELEASE%\data\accounts.example.json" >nul

--- a/build-tray.bat
+++ b/build-tray.bat
@@ -10,8 +10,10 @@ set "WV2_DIR=.build\webview2\%WV2_VERSION%"
 set "WV2_CORE=%WV2_DIR%\lib\net462\Microsoft.Web.WebView2.Core.dll"
 set "WV2_WINFORMS=%WV2_DIR%\lib\net462\Microsoft.Web.WebView2.WinForms.dll"
 set "WV2_LOADER=%WV2_DIR%\runtimes\win-x64\native\WebView2Loader.dll"
+set "WINDOWS_OUT=.build\windows"
 
 if not exist ".build" mkdir ".build"
+if not exist "%WINDOWS_OUT%" mkdir "%WINDOWS_OUT%"
 
 if not exist "%CSC%" (
   echo [ERROR] .NET Framework C# compiler not found.
@@ -31,12 +33,12 @@ if not exist "%WV2_CORE%" (
 )
 
 echo [3/4] Compiling the single desktop application...
-"%CSC%" /nologo /target:winexe /platform:x64 /win32icon:icon\tray-icon.ico /win32manifest:app.manifest /out:TypelessToolkit.exe /reference:System.Windows.Forms.dll /reference:System.Drawing.dll /reference:"%WV2_CORE%" /reference:"%WV2_WINFORMS%" main.cs
+"%CSC%" /nologo /target:winexe /platform:x64 /win32icon:icon\tray-icon.ico /win32manifest:app.manifest /out:"%WINDOWS_OUT%\TypelessToolkit.exe" /reference:System.Windows.Forms.dll /reference:System.Drawing.dll /reference:"%WV2_CORE%" /reference:"%WV2_WINFORMS%" main.cs
 if errorlevel 1 exit /b 1
 
-copy /Y "%WV2_CORE%" . >nul
-copy /Y "%WV2_WINFORMS%" . >nul
-copy /Y "%WV2_LOADER%" . >nul
+copy /Y "%WV2_CORE%" "%WINDOWS_OUT%\Microsoft.Web.WebView2.Core.dll" >nul
+copy /Y "%WV2_WINFORMS%" "%WINDOWS_OUT%\Microsoft.Web.WebView2.WinForms.dll" >nul
+copy /Y "%WV2_LOADER%" "%WINDOWS_OUT%\WebView2Loader.dll" >nul
 
-echo [4/4] Done: TypelessToolkit.exe
+echo [4/4] Done: %WINDOWS_OUT%\TypelessToolkit.exe
 endlocal

--- a/lib/common.js
+++ b/lib/common.js
@@ -75,7 +75,18 @@ function loadConfig() {
   cfg.paywall = { ...DEFAULT_CONFIG.paywall, ...(cfg.paywall || {}) };
   cfg.paywall.replacements = cfg.paywall.replacements && cfg.paywall.replacements.length
     ? cfg.paywall.replacements : DEFAULT_CONFIG.paywall.replacements;
-  return { ...DEFAULT_CONFIG, ...cfg };
+  const merged = { ...DEFAULT_CONFIG, ...cfg };
+  merged.manager_port = resolveManagerPort(merged.manager_port, process.env.TYPELESS_MANAGER_PORT);
+  return merged;
+}
+
+function resolveManagerPort(configuredPort, environmentPort) {
+  const configured = Number(configuredPort);
+  const fallback = Number.isInteger(configured) && configured > 0 && configured <= 65535
+    ? configured : DEFAULT_CONFIG.manager_port;
+  if (environmentPort === undefined || environmentPort === null || environmentPort === '') return fallback;
+  const overridden = Number(environmentPort);
+  return Number.isInteger(overridden) && overridden > 0 && overridden <= 65535 ? overridden : fallback;
 }
 const config = loadConfig();
 
@@ -1232,7 +1243,7 @@ module.exports = {
   API_BASE, CDP_PORT, MASTER_CSV, PROFILES_DIR, ACCOUNTS_FILE, SNAPSHOT_FILES,
   // 工具
   log, sleep, execAsync, execFileAsync,
-  detectTypelessExe, loadConfig, envInfo,
+  detectTypelessExe, loadConfig, resolveManagerPort, envInfo,
   // 账号 / 快照
   readAccounts, writeAccounts, readCurrentUser, currentUserFromStorage,
   saveSnapshot, restoreSnapshot, hasSnapshot,

--- a/main.cs
+++ b/main.cs
@@ -18,9 +18,9 @@ using Microsoft.Web.WebView2.WinForms;
 [assembly: AssemblyDescription("Typeless desktop account and dictionary toolkit")]
 [assembly: AssemblyCompany("Typeless Toolkit Contributors")]
 [assembly: AssemblyCopyright("Copyright (c) 2026 Typeless Toolkit Contributors")]
-[assembly: AssemblyVersion("1.4.1.0")]
-[assembly: AssemblyFileVersion("1.4.1.0")]
-[assembly: AssemblyInformationalVersion("1.4.1")]
+[assembly: AssemblyVersion("1.4.2.0")]
+[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyInformationalVersion("1.4.2")]
 
 class TrayApp
 {
@@ -108,16 +108,39 @@ class TrayApp
         if (IsPortOpen())
         {
             if (ProbeToolkit()) return true;
-            backendError = "端口 " + managerPort + " 已被其他程序占用，且 /api/env 不是 Typeless Toolkit 服务。请修改 data\\config.json 中的 manager_port。";
-            return false;
+            int occupiedPort = managerPort;
+            if (!UseFallbackPort())
+            {
+                backendError = "端口 " + occupiedPort + " 已被其他程序占用，且找不到可用的回退端口。请修改 data\\config.json 中的 manager_port。";
+                return false;
+            }
+            AppendLauncherLog("端口 " + occupiedPort + " 已被其他程序占用，本次改用 " + managerPort + "。 ");
+        }
+        else if (!CanBindPort(managerPort))
+        {
+            int unavailablePort = managerPort;
+            if (!UseFallbackPort())
+            {
+                backendError = "端口 " + unavailablePort + " 无法绑定，且找不到可用的回退端口。该端口可能被 Windows 保留，请修改 data\\config.json 中的 manager_port。";
+                return false;
+            }
+            AppendLauncherLog("端口 " + unavailablePort + " 无法绑定（可能被 Windows 保留），本次改用 " + managerPort + "。 ");
         }
 
         string node = FindNode();
-        if (node == null) return false;
+        if (node == null)
+        {
+            backendError = "未找到 Node.js。Portable 版应包含 runtime\\node.exe；Lite 版需要安装 Node.js 22.12+。";
+            return false;
+        }
 
         string serverDir = Path.Combine(exeDir, "server");
         string manager = Path.Combine(serverDir, "manager.js");
-        if (!File.Exists(manager)) return false;
+        if (!File.Exists(manager))
+        {
+            backendError = "缺少后端文件：" + manager + "。请完整解压发行包，不要单独复制或运行源码根目录中的 EXE。";
+            return false;
+        }
 
         string dataDir = Path.Combine(exeDir, "data");
         Directory.CreateDirectory(dataDir);
@@ -128,10 +151,16 @@ class TrayApp
         nodeProcess.StartInfo.WorkingDirectory = serverDir;
         nodeProcess.StartInfo.CreateNoWindow = true;
         nodeProcess.StartInfo.UseShellExecute = false;
+        nodeProcess.StartInfo.RedirectStandardError = true;
         nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_DATA_DIR"] = dataDir;
+        nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_MANAGER_PORT"] = managerPort.ToString();
 
         try { nodeProcess.Start(); }
-        catch { return false; }
+        catch (Exception error)
+        {
+            backendError = "无法启动 Node.js 后端：" + error.Message;
+            return false;
+        }
 
         for (int i = 0; i < 30; i++)
         {
@@ -142,10 +171,73 @@ class TrayApp
                 backendError = "端口 " + managerPort + " 已被其他程序占用，无法确认本地服务身份。";
                 return false;
             }
-            if (nodeProcess.HasExited) return false;
+            if (nodeProcess.HasExited)
+            {
+                string details = "";
+                try { details = nodeProcess.StandardError.ReadToEnd().Trim(); } catch { }
+                backendError = details.Length > 0
+                    ? "Node.js 后端启动失败：" + details
+                    : "Node.js 后端已退出，退出代码 " + nodeProcess.ExitCode + "。";
+                AppendLauncherLog(backendError);
+                return false;
+            }
         }
         backendError = "本地服务在端口 " + managerPort + " 上启动超时。";
         return false;
+    }
+
+    static bool CanBindPort(int port)
+    {
+        TcpListener listener = null;
+        try
+        {
+            listener = new TcpListener(IPAddress.Loopback, port);
+            listener.ExclusiveAddressUse = true;
+            listener.Start();
+            return true;
+        }
+        catch { return false; }
+        finally { if (listener != null) try { listener.Stop(); } catch { } }
+    }
+
+    static bool UseFallbackPort()
+    {
+        int preferred = managerPort;
+        for (int offset = 1; offset <= 100; offset++)
+        {
+            int candidate = preferred + offset;
+            if (candidate > 65535) break;
+            if (CanBindPort(candidate))
+            {
+                managerPort = candidate;
+                baseUrl = "http://127.0.0.1:" + managerPort;
+                return true;
+            }
+        }
+        for (int candidate = 17888; candidate <= 17988; candidate++)
+        {
+            if (CanBindPort(candidate))
+            {
+                managerPort = candidate;
+                baseUrl = "http://127.0.0.1:" + managerPort;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static void AppendLauncherLog(string message)
+    {
+        try
+        {
+            string dataDir = Path.Combine(exeDir, "data");
+            Directory.CreateDirectory(dataDir);
+            File.AppendAllText(
+                Path.Combine(dataDir, "launcher.log"),
+                DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + " " + message.Trim() + Environment.NewLine
+            );
+        }
+        catch { }
     }
 
     static int ReadManagerPort()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeless-toolkit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typeless-toolkit",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@electron/fuses": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeless-toolkit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Typeless 多账号管理、词库同步与桌面工具集（Windows WebView2 / macOS Electron）。",
   "main": "electron-main.js",
   "author": "Typeless Toolkit contributors",

--- a/test/paywall-detection.test.js
+++ b/test/paywall-detection.test.js
@@ -2,7 +2,18 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 process.env.TYPELESS_EXE = '/path/that/does/not/exist';
-const { currentUserFromStorage, locatePaywallTarget, resolvePaywallReplacements } = require('../lib/common');
+const {
+  currentUserFromStorage,
+  locatePaywallTarget,
+  resolveManagerPort,
+  resolvePaywallReplacements,
+} = require('../lib/common');
+
+test('lets the desktop host override an unavailable configured manager port', () => {
+  assert.equal(resolveManagerPort(7788, '7816'), 7816);
+  assert.equal(resolveManagerPort(7788, 'not-a-port'), 7788);
+  assert.equal(resolveManagerPort(7788, '70000'), 7788);
+});
 
 test('reads the current account from local Typeless storage without CDP', () => {
   assert.deepEqual(currentUserFromStorage({ userData: { user_id: 'user-1', email: 'user@example.com' } }), {


### PR DESCRIPTION
修复默认 7788 落入 Windows 保留端口范围时 Portable/Lite 后端立即退出的问题；宿主现在会选择可绑定的回退端口并将实际端口传给 Node，同时展示真实启动错误。Windows 编译产物迁移到 .build/windows，源码根目录不再散落 EXE/DLL；自用与公开构建只安装生产依赖。版本更新为 1.4.2。\n\n验证：npm run check 9/9；build-tray、build-release、build-public-release 通过；在本机 7788 被系统保留的情况下，Portable 自动使用 7816，/api/env 身份与端口验证通过。