### PR TITLE
修复启动日志写入用户 data

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -230,10 +230,13 @@ class TrayApp
     {
         try
         {
-            string dataDir = Path.Combine(exeDir, "data");
-            Directory.CreateDirectory(dataDir);
+            string logDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "TypelessToolkit"
+            );
+            Directory.CreateDirectory(logDir);
             File.AppendAllText(
-                Path.Combine(dataDir, "launcher.log"),
+                Path.Combine(logDir, "launcher.log"),
                 DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + " " + message.Trim() + Environment.NewLine
             );
         }


### PR DESCRIPTION
将 Windows 宿主的端口回退与启动错误日志从发行目录 data/ 移到 %LOCALAPPDATA%/TypelessToolkit/launcher.log，保证程序更新和正常启动不向账号数据目录新增日志文件。build-tray.bat 编译通过。