### PR TITLE
feat: 加入 Typeless 工具集引导式自更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ macOS Release 提供 Universal DMG，同时支持 Apple Silicon 与 Intel Mac。
 拖入“应用程序”即可；升级只替换 App 本体，账号、快照、词库和配置继续保存在
 `~/Library/Application Support/Typeless 工具集/data/`。每个附件均提供独立 SHA-256 校验文件。
 
+工具集会在启动后检查 GitHub Release，并展示版本说明。Windows 的 Portable/Lite 包可由工具集下载、
+校验 SHA-256 后在退出时自动替换程序文件，保留 `data/` 中的账号、快照、词库和配置；macOS 当前
+使用 ad-hoc 签名，工具集会下载并打开已校验的 DMG，仍需手动拖入“应用程序”完成替换。这里的
+“工具集更新”与“安装 Typeless 官方更新”是两个独立入口，后者只处理 Typeless 本体。
+
 两个版本都只有一个需要操作的入口，并会把账号、配置和快照保存在解压目录的 `data/` 中。
 升级时请保留该目录。除此之外还需要：
 
@@ -101,6 +106,7 @@ release 版只有一个入口：`TypelessToolkit.exe`。
 | 去升级弹窗 | 管理器 | 启动、账号变更和官方更新后自动检查修复；自动定位付费墙调用、处理完整性校验，手动入口仅用于状态查看和重试 |
 | 跳过新手引导 | 管理器 | 双写 onboarding 状态并保存到账号快照,切号后自动修复,再重启 Typeless |
 | 安装 Typeless 官方更新 | 管理器(macOS) | 校验 SHA-512、版本、Bundle ID、Developer ID 与 Gatekeeper 后安装 Typeless updater 已下载的本地缓存包,失败自动回滚；不更新 Toolkit |
+| 工具集更新 | 管理器 | 检查 GitHub Release、展示说明并下载 SHA-256 校验包；Windows 退出后自动替换代码且保留 `data/`，macOS 仅打开已校验 DMG 供手动安装 |
 
 ## 配置说明
 

--- a/electron-main.js
+++ b/electron-main.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { app, BrowserWindow, dialog, ipcMain, nativeTheme, shell } = require('electron');
@@ -167,11 +168,24 @@ ipcMain.handle('typeless-toolkit:open-toolkit-update-file', async (event, filePa
   }
   if (process.platform !== 'darwin') return { ok: false, message: '仅支持 macOS' };
   const target = path.resolve(String(filePath || ''));
-  if (!/^Typeless-Toolkit-\d+(?:\.\d+)+-universal\.dmg$/i.test(path.basename(target))) {
+  const expectedName = /^Typeless-Toolkit-\d+(?:\.\d+)+-universal\.dmg$/i;
+  if (!expectedName.test(path.basename(target))) {
     return { ok: false, message: '不是受支持的工具集更新包' };
   }
-  if (!fs.existsSync(target)) return { ok: false, message: '已下载的 DMG 不存在，请重新下载' };
-  const error = await shell.openPath(target);
+  let realTarget, realStage, realTemp;
+  try {
+    const info = fs.lstatSync(target);
+    if (!info.isFile() || info.isSymbolicLink()) throw new Error('invalid-file');
+    realTarget = fs.realpathSync(target);
+    realStage = fs.realpathSync(path.dirname(realTarget));
+    realTemp = fs.realpathSync(os.tmpdir());
+  } catch (error) {
+    return { ok: false, message: '已下载的 DMG 不存在或不是普通文件，请重新下载' };
+  }
+  if (path.dirname(realStage) !== realTemp || !path.basename(realStage).startsWith('typeless-toolkit-update-') || path.dirname(realTarget) !== realStage) {
+    return { ok: false, message: '更新包不在受支持的临时下载目录，请重新下载' };
+  }
+  const error = await shell.openPath(realTarget);
   return error ? { ok: false, message: error } : { ok: true };
 });
 

--- a/electron-main.js
+++ b/electron-main.js
@@ -161,6 +161,20 @@ ipcMain.handle('typeless-toolkit:reset-privacy-permissions', (event, target) => 
   return { ok: true, message: `已清除 ${plan.appName} 的旧权限记录，请重新启动并按系统提示授权` };
 });
 
+ipcMain.handle('typeless-toolkit:open-toolkit-update-file', async (event, filePath) => {
+  if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) {
+    return { ok: false, message: '无效的窗口请求' };
+  }
+  if (process.platform !== 'darwin') return { ok: false, message: '仅支持 macOS' };
+  const target = path.resolve(String(filePath || ''));
+  if (!/^Typeless-Toolkit-\d+(?:\.\d+)+-universal\.dmg$/i.test(path.basename(target))) {
+    return { ok: false, message: '不是受支持的工具集更新包' };
+  }
+  if (!fs.existsSync(target)) return { ok: false, message: '已下载的 DMG 不存在，请重新下载' };
+  const error = await shell.openPath(target);
+  return error ? { ok: false, message: error } : { ok: true };
+});
+
 async function launch() {
   const dataDir = prepareDataDirectory();
   const permissionIdentity = reconcileToolkitPermissionIdentity(dataDir);

--- a/electron-preload.js
+++ b/electron-preload.js
@@ -15,4 +15,7 @@ contextBridge.exposeInMainWorld('typelessToolkitDesktop', {
     if (target !== 'typeless' && target !== 'toolkit') return { ok: false };
     return ipcRenderer.invoke('typeless-toolkit:reset-privacy-permissions', target);
   },
+  async openToolkitUpdateFile(filePath) {
+    return ipcRenderer.invoke('typeless-toolkit:open-toolkit-update-file', String(filePath || ''));
+  },
 });

--- a/lib/toolkit-update.js
+++ b/lib/toolkit-update.js
@@ -352,6 +352,8 @@ if (Test-Path -LiteralPath $rollback) { throw '临时回退目录已存在，请
 if ([IO.Path]::GetFullPath($RestartExe) -ne (Join-Path $install 'TypelessToolkit.exe')) { throw '重启程序路径无效。' }
 $deadline = (Get-Date).AddSeconds(75)
 $rollbackStarted = $false
+$oldMoveCompleted = $false
+$replacementStarted = $false
 $newProcess = $null
 try {
   while ((Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) -or (Get-Process -Id $HostPid -ErrorAction SilentlyContinue)) {
@@ -367,6 +369,8 @@ try {
   Get-ChildItem -LiteralPath $install -Force | Where-Object { $_.Name -ne 'data' -and $_.FullName -ne $rollback } | ForEach-Object {
     Move-Item -LiteralPath $_.FullName -Destination $rollback -Force
   }
+  $oldMoveCompleted = $true
+  $replacementStarted = $true
   Get-ChildItem -LiteralPath $payload -Force | Where-Object { $_.Name -ne 'data' } | ForEach-Object {
     Copy-Item -LiteralPath $_.FullName -Destination $install -Recurse -Force
   }
@@ -381,7 +385,9 @@ try {
   if ($newProcess -and !$newProcess.HasExited) { try { Stop-Process -Id $newProcess.Id -Force } catch { } }
   if ($rollbackStarted) {
     try {
-      Get-ChildItem -LiteralPath $install -Force | Where-Object { $_.Name -ne 'data' -and $_.FullName -ne $rollback } | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force }
+      if ($oldMoveCompleted -and $replacementStarted) {
+        Get-ChildItem -LiteralPath $install -Force | Where-Object { $_.Name -ne 'data' -and $_.FullName -ne $rollback } | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force }
+      }
       Get-ChildItem -LiteralPath $rollback -Force | ForEach-Object { Move-Item -LiteralPath $_.FullName -Destination $install -Force }
       Remove-Item -LiteralPath $rollback -Recurse -Force
       Start-Process -FilePath $RestartExe -WorkingDirectory $install

--- a/lib/toolkit-update.js
+++ b/lib/toolkit-update.js
@@ -479,11 +479,11 @@ function createToolkitUpdateController(options = {}) {
       state.update = update;
       state.state = update.available ? (update.manual_only ? 'manual-only' : (update.error ? 'incomplete' : 'available')) : 'up-to-date';
       state.error = update.error;
-      return snapshot();
     } catch (error) {
       state.state = 'error'; state.error = error.message; state.update = null;
       throw error;
     } finally { state.running = false; }
+    return snapshot();
   }
 
   async function download() {

--- a/lib/toolkit-update.js
+++ b/lib/toolkit-update.js
@@ -2,11 +2,17 @@ const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { Readable } = require('stream');
+const { Readable, Transform } = require('stream');
+const { pipeline } = require('stream/promises');
 const { spawn, spawnSync } = require('child_process');
 
 const DEFAULT_REPOSITORY = 'Jia131313/typeless-toolkit';
 const MAX_RELEASE_DOWNLOAD_BYTES = 1024 * 1024 * 1024;
+const STAGING_PREFIX = 'typeless-toolkit-update-';
+const MAX_ZIP_ENTRIES = 5000;
+const MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024;
+const MAX_ZIP_SINGLE_FILE_BYTES = 512 * 1024 * 1024;
+const MAX_ZIP_COMPRESSION_RATIO = 100;
 
 function compareVersions(left, right) {
   const parse = value => String(value || '')
@@ -29,12 +35,57 @@ function releaseVersion(tagName) {
   return match ? match[1] : null;
 }
 
-function windowsFlavor(codeRoot) {
-  return fs.existsSync(path.join(codeRoot, '..', 'runtime', 'node.exe')) ? 'portable' : 'lite';
+function installationInfo(codeRoot, dataRoot) {
+  const installDir = path.resolve(codeRoot, '..');
+  const expectedDataDir = path.join(installDir, 'data');
+  const result = {
+    ok: false,
+    install_dir: installDir,
+    edition: null,
+    error: null,
+  };
+  if (path.parse(installDir).root === installDir) {
+    result.error = '拒绝将磁盘根目录作为更新安装目录';
+    return result;
+  }
+  if (path.resolve(codeRoot) !== path.join(installDir, 'server')) {
+    result.error = '当前代码目录不是受支持的发行版 server 目录';
+    return result;
+  }
+  if (path.resolve(dataRoot) !== expectedDataDir) {
+    result.error = '当前数据目录不在发行版 data 目录，不能自动替换';
+    return result;
+  }
+  for (const required of [
+    path.join(installDir, 'TypelessToolkit.exe'),
+    path.join(installDir, 'server', 'manager.js'),
+    path.join(installDir, 'server', 'package.json'),
+    expectedDataDir,
+  ]) {
+    if (!fs.existsSync(required)) {
+      result.error = `当前发行版目录不完整: ${path.basename(required)}`;
+      return result;
+    }
+  }
+  try {
+    if (!fs.statSync(expectedDataDir).isDirectory()) throw new Error('not-directory');
+  } catch (error) {
+    result.error = '当前发行版 data 目录无效';
+    return result;
+  }
+  const nodePath = path.join(installDir, 'runtime', 'node.exe');
+  result.ok = true;
+  result.edition = fs.existsSync(nodePath) ? 'portable' : 'lite';
+  return result;
+}
+
+function windowsFlavor(codeRoot, dataRoot) {
+  return installationInfo(codeRoot, dataRoot || path.join(codeRoot, '..', 'data')).edition;
 }
 
 function assetNames(version, platform, flavor) {
   if (platform === 'win32') {
+    if (!['portable', 'lite'].includes(flavor)) return null;
     const archive = `TypelessToolkit-v${version}-win-x64-${flavor}.zip`;
     return { archive, checksum: `${archive}.sha256.txt` };
   }
@@ -68,6 +119,31 @@ function isSafeZipEntry(name) {
     !normalized.split('/').includes('..');
 }
 
+function validateZipEntryMetadata(entry) {
+  const name = String(entry?.name || '');
+  const length = Number(entry?.length || 0);
+  const compressedLength = Number(entry?.compressedLength || 0);
+  if (!isSafeZipEntry(name)) throw new Error(`更新包包含不安全路径: ${name}`);
+  if (!Number.isFinite(length) || length < 0 || length > MAX_ZIP_SINGLE_FILE_BYTES) {
+    throw new Error(`更新包文件大小超出上限: ${name}`);
+  }
+  if (length > 0 && (!Number.isFinite(compressedLength) || compressedLength <= 0 || length / compressedLength > MAX_ZIP_COMPRESSION_RATIO)) {
+    throw new Error(`更新包压缩比例异常: ${name}`);
+  }
+}
+
+function validateZipMetadata(entries) {
+  if (!Array.isArray(entries) || entries.length > MAX_ZIP_ENTRIES) {
+    throw new Error('更新包文件数量超出上限');
+  }
+  let total = 0;
+  for (const entry of entries) {
+    validateZipEntryMetadata(entry);
+    total += Number(entry.length || 0);
+    if (total > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES) throw new Error('更新包解压总大小超出上限');
+  }
+}
+
 async function sha256File(filePath) {
   const hash = crypto.createHash('sha256');
   await new Promise((resolve, reject) => {
@@ -90,19 +166,22 @@ async function downloadToFile(url, filePath, options = {}) {
   if (!response.ok || !response.body) throw new Error(`下载更新包失败: HTTP ${response.status}`);
   const total = Number(response.headers?.get?.('content-length') || 0);
   if (total && total > maxBytes) throw new Error('更新包大小超出安全上限');
-  const output = fs.createWriteStream(filePath, { flags: 'w', mode: 0o600 });
   let downloaded = 0;
-  const body = Readable.fromWeb(response.body);
-  try {
-    for await (const chunk of body) {
+  const meter = new Transform({
+    transform(chunk, encoding, callback) {
       downloaded += chunk.length;
-      if (downloaded > maxBytes) throw new Error('更新包大小超出安全上限');
-      if (!output.write(chunk)) await new Promise(resolve => output.once('drain', resolve));
+      if (downloaded > maxBytes) return callback(new Error('更新包大小超出安全上限'));
       onProgress(downloaded, total);
-    }
-    await new Promise((resolve, reject) => output.end(error => error ? reject(error) : resolve()));
+      callback(null, chunk);
+    },
+  });
+  try {
+    await pipeline(
+      Readable.fromWeb(response.body),
+      meter,
+      fs.createWriteStream(filePath, { flags: 'w', mode: 0o600 }),
+    );
   } catch (error) {
-    output.destroy();
     try { fs.unlinkSync(filePath); } catch (unlinkError) {}
     throw error;
   }
@@ -132,7 +211,9 @@ function releaseSummary(release, version, currentVersion, platform, flavor) {
       name: checksum.name,
       url: checksum.browser_download_url,
     } : null,
-    error: archive && checksum ? null : `该版本未提供当前平台所需的更新包或 SHA-256 校验文件（需要 ${names.archive} 与 ${names.checksum}）`,
+    error: !names
+      ? '当前 Windows 安装类型无法确认，请从 Release 手动升级'
+      : (archive && checksum ? null : `该版本未提供当前平台所需的更新包或 SHA-256 校验文件（需要 ${names.archive} 与 ${names.checksum}）`),
   };
 }
 
@@ -167,24 +248,51 @@ function safeExtractZipWindows(zipPath, outputDir, options = {}) {
   const script = [
     '$ErrorActionPreference = "Stop"',
     'Add-Type -AssemblyName System.IO.Compression.FileSystem',
+    '$destinationRoot = [IO.Path]::GetFullPath($args[1])',
+    '$destinationPrefix = $destinationRoot.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar',
+    '$maxEntries = [int]$args[2]; $maxTotal = [int64]$args[3]; $maxSingle = [int64]$args[4]; $maxRatio = [double]$args[5]',
+    '$entryCount = 0; $totalLength = [int64]0',
     '$zip = [System.IO.Compression.ZipFile]::OpenRead($args[0])',
     'try {',
     '  foreach ($entry in $zip.Entries) {',
     '    $name = $entry.FullName.Replace("\\", "/")',
     '    if (!$name -or $name.StartsWith("/") -or $name -match "^[A-Za-z]:/" -or $name.Split("/") -contains "..") { throw "更新包包含不安全路径: $name" }',
+    '    $candidate = [IO.Path]::GetFullPath([IO.Path]::Combine($destinationRoot, $name.Replace("/", [IO.Path]::DirectorySeparatorChar)))',
+    '    if (!$candidate.StartsWith($destinationPrefix, [StringComparison]::OrdinalIgnoreCase)) { throw "更新包路径超出解压目录: $name" }',
+    '    $entryCount++; if ($entryCount -gt $maxEntries) { throw "更新包文件数量超出上限" }',
+    '    if ($entry.Length -gt $maxSingle) { throw "更新包单文件大小超出上限: $name" }',
+    '    $totalLength += $entry.Length; if ($totalLength -gt $maxTotal) { throw "更新包解压总大小超出上限" }',
+    '    if ($entry.Length -gt 0 -and ($entry.CompressedLength -le 0 -or ([double]$entry.Length / [double]$entry.CompressedLength) -gt $maxRatio)) { throw "更新包压缩比例异常: $name" }',
     '  }',
     '} finally { $zip.Dispose() }',
     '[System.IO.Compression.ZipFile]::ExtractToDirectory($args[0], $args[1])',
   ].join('; ');
-  powershell(script, [zipPath, outputDir], options);
+  powershell(script, [zipPath, outputDir, MAX_ZIP_ENTRIES, MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES, MAX_ZIP_SINGLE_FILE_BYTES, MAX_ZIP_COMPRESSION_RATIO], options);
 }
 
-function validateWindowsPayload(payloadDir) {
+function validateWindowsPayload(payloadDir, targetVersion, flavor) {
   const executable = path.join(payloadDir, 'TypelessToolkit.exe');
   const manager = path.join(payloadDir, 'server', 'manager.js');
-  if (!fs.existsSync(executable) || !fs.existsSync(manager)) {
+  const packageFile = path.join(payloadDir, 'server', 'package.json');
+  const dataDir = path.join(payloadDir, 'data');
+  if (!fs.existsSync(executable) || !fs.existsSync(manager) || !fs.existsSync(packageFile) || !fs.existsSync(dataDir)) {
     throw new Error('更新包内容不完整，未找到启动器或本地服务');
   }
+  let packageJson;
+  try { packageJson = JSON.parse(fs.readFileSync(packageFile, 'utf8')); } catch (error) {
+    throw new Error('更新包中的 server/package.json 无法读取');
+  }
+  if (String(packageJson.version || '') !== String(targetVersion || '')) {
+    throw new Error('更新包版本与目标 Release 不一致');
+  }
+  const bundledNode = path.join(payloadDir, 'runtime', 'node.exe');
+  if (flavor === 'portable' && !fs.existsSync(bundledNode)) {
+    throw new Error('Portable 更新包缺少内置 Node.js');
+  }
+  if (flavor === 'lite' && fs.existsSync(bundledNode)) {
+    throw new Error('Lite 更新包包含内置 Node.js，已取消替换');
+  }
+  if (!['portable', 'lite'].includes(flavor)) throw new Error('无法确认更新包的 Windows 类型');
 }
 
 function resolveWindowsPayloadRoot(extractedDir) {
@@ -206,24 +314,83 @@ function writeWindowsUpdateHelper(stageDir) {
   [Parameter(Mandatory=$true)][string]$InstallDir,
   [Parameter(Mandatory=$true)][string]$PayloadDir,
   [Parameter(Mandatory=$true)][string]$RestartExe,
-  [Parameter(Mandatory=$true)][string]$StageDir
+  [Parameter(Mandatory=$true)][string]$StageDir,
+  [Parameter(Mandatory=$true)][string]$RollbackDir,
+  [Parameter(Mandatory=$true)][string]$ResultPath,
+  [Parameter(Mandatory=$true)][string]$TargetVersion,
+  [Parameter(Mandatory=$true)][string]$Flavor
 )
 $ErrorActionPreference = 'Stop'
+function Assert-ChildPath([string]$parent, [string]$child) {
+  $base = [IO.Path]::GetFullPath($parent).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+  $full = [IO.Path]::GetFullPath($child)
+  $prefix = $base + [IO.Path]::DirectorySeparatorChar
+  if (!$full.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) { throw "路径超出受支持目录: $full" }
+  return $full
+}
+function Assert-Payload([string]$root, [string]$version, [string]$edition) {
+  if (!(Test-Path -LiteralPath (Join-Path $root 'TypelessToolkit.exe')) -or !(Test-Path -LiteralPath (Join-Path $root 'server\manager.js')) -or !(Test-Path -LiteralPath (Join-Path $root 'server\package.json')) -or !(Test-Path -LiteralPath (Join-Path $root 'data'))) { throw '更新包或安装目录结构不完整。' }
+  try { $manifest = Get-Content -LiteralPath (Join-Path $root 'server\package.json') -Raw | ConvertFrom-Json } catch { throw 'server/package.json 无法读取。' }
+  if ([string]$manifest.version -ne [string]$version) { throw '更新包版本与目标 Release 不一致。' }
+  $node = Join-Path $root 'runtime\node.exe'
+  if ($edition -eq 'portable' -and !(Test-Path -LiteralPath $node)) { throw 'Portable 更新包缺少内置 Node.js。' }
+  if ($edition -eq 'lite' -and (Test-Path -LiteralPath $node)) { throw 'Lite 更新包包含内置 Node.js。' }
+  if ($edition -ne 'portable' -and $edition -ne 'lite') { throw '无法确认 Windows 更新包类型。' }
+}
+function Write-Result([string]$state, [string]$message) {
+  try {
+    @{ state = $state; version = $TargetVersion; at = (Get-Date).ToUniversalTime().ToString('o'); message = $message } | ConvertTo-Json -Compress | Set-Content -LiteralPath $ResultPath -Encoding UTF8
+  } catch { }
+}
+$install = [IO.Path]::GetFullPath($InstallDir)
+if ($install.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) -eq [IO.Path]::GetPathRoot($install).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)) { throw '拒绝将磁盘根目录作为更新安装目录。' }
+$payload = Assert-ChildPath $StageDir $PayloadDir
+$rollback = Assert-ChildPath $install $RollbackDir
+$result = Assert-ChildPath (Join-Path $install 'data') $ResultPath
+if ((Split-Path -Leaf $rollback) -notmatch '^\.typeless-toolkit-update-rollback-[A-Za-z0-9]+$') { throw '临时回退目录名称无效。' }
+if (Test-Path -LiteralPath $rollback) { throw '临时回退目录已存在，请重试更新。' }
+if ([IO.Path]::GetFullPath($RestartExe) -ne (Join-Path $install 'TypelessToolkit.exe')) { throw '重启程序路径无效。' }
 $deadline = (Get-Date).AddSeconds(75)
-while ((Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) -or (Get-Process -Id $HostPid -ErrorAction SilentlyContinue)) {
-  if ((Get-Date) -gt $deadline) { throw '旧版工具集未在 75 秒内退出；请手动退出后重试。' }
-  Start-Sleep -Milliseconds 250
+$rollbackStarted = $false
+$newProcess = $null
+try {
+  while ((Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) -or (Get-Process -Id $HostPid -ErrorAction SilentlyContinue)) {
+    if ((Get-Date) -gt $deadline) { throw '旧版工具集未在 75 秒内退出；请手动退出后重试。' }
+    Start-Sleep -Milliseconds 250
+  }
+  Assert-Payload $payload $TargetVersion $Flavor
+  $currentManifest = Get-Content -LiteralPath (Join-Path $install 'server\package.json') -Raw | ConvertFrom-Json
+  $currentFlavor = if (Test-Path -LiteralPath (Join-Path $install 'runtime\node.exe')) { 'portable' } else { 'lite' }
+  Assert-Payload $install ([string]$currentManifest.version) $currentFlavor
+  New-Item -ItemType Directory -LiteralPath $rollback | Out-Null
+  $rollbackStarted = $true
+  Get-ChildItem -LiteralPath $install -Force | Where-Object { $_.Name -ne 'data' -and $_.FullName -ne $rollback } | ForEach-Object {
+    Move-Item -LiteralPath $_.FullName -Destination $rollback -Force
+  }
+  Get-ChildItem -LiteralPath $payload -Force | Where-Object { $_.Name -ne 'data' } | ForEach-Object {
+    Copy-Item -LiteralPath $_.FullName -Destination $install -Recurse -Force
+  }
+  Assert-Payload $install $TargetVersion $Flavor
+  $newProcess = Start-Process -FilePath $RestartExe -WorkingDirectory $install -PassThru
+  Start-Sleep -Seconds 4
+  if ($newProcess.HasExited) { throw "新版工具集启动失败，退出代码 $($newProcess.ExitCode)。" }
+  Remove-Item -LiteralPath $rollback -Recurse -Force
+  Write-Result 'succeeded' "已更新到 v$TargetVersion。"
+} catch {
+  $message = $_.Exception.Message
+  if ($newProcess -and !$newProcess.HasExited) { try { Stop-Process -Id $newProcess.Id -Force } catch { } }
+  if ($rollbackStarted) {
+    try {
+      Get-ChildItem -LiteralPath $install -Force | Where-Object { $_.Name -ne 'data' -and $_.FullName -ne $rollback } | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force }
+      Get-ChildItem -LiteralPath $rollback -Force | ForEach-Object { Move-Item -LiteralPath $_.FullName -Destination $install -Force }
+      Remove-Item -LiteralPath $rollback -Recurse -Force
+      Start-Process -FilePath $RestartExe -WorkingDirectory $install
+      Write-Result 'rolled-back' "更新失败，已恢复原版本：$message"
+    } catch {
+      Write-Result 'failed' "更新失败，且恢复原版本失败：$message；$($_.Exception.Message)"
+    }
+  } else { Write-Result 'failed' "更新未开始替换：$message" }
 }
-if (!(Test-Path -LiteralPath (Join-Path $PayloadDir 'TypelessToolkit.exe')) -or !(Test-Path -LiteralPath (Join-Path $PayloadDir 'server\manager.js'))) {
-  throw '更新包内容不完整，已取消替换。'
-}
-Get-ChildItem -LiteralPath $InstallDir -Force | Where-Object { $_.Name -ne 'data' } | ForEach-Object {
-  Remove-Item -LiteralPath $_.FullName -Recurse -Force
-}
-Get-ChildItem -LiteralPath $PayloadDir -Force | ForEach-Object {
-  if ($_.Name -ne 'data') { Copy-Item -LiteralPath $_.FullName -Destination $InstallDir -Recurse -Force }
-}
-Start-Process -FilePath $RestartExe -WorkingDirectory $InstallDir
 $cleanup = 'timeout /t 5 /nobreak >nul & rmdir /s /q "' + $StageDir + '"'
 Start-Process -FilePath $env:ComSpec -ArgumentList '/d', '/c', $cleanup -WindowStyle Hidden
 `;
@@ -231,8 +398,10 @@ Start-Process -FilePath $env:ComSpec -ArgumentList '/d', '/c', $cleanup -WindowS
   return helperPath;
 }
 
-function launchWindowsUpdateHelper({ parentPid, hostPid, installDir, payloadDir, helperPath }) {
+function launchWindowsUpdateHelper({ parentPid, hostPid, installDir, payloadDir, helperPath, version, flavor }) {
   const restartExe = path.join(installDir, 'TypelessToolkit.exe');
+  const rollbackDir = path.join(installDir, `.typeless-toolkit-update-rollback-${crypto.randomBytes(8).toString('hex')}`);
+  const resultPath = path.join(installDir, 'data', 'toolkit-update-result.json');
   const child = spawn('powershell.exe', [
     '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', helperPath,
     '-ParentPid', String(parentPid),
@@ -241,6 +410,10 @@ function launchWindowsUpdateHelper({ parentPid, hostPid, installDir, payloadDir,
     '-PayloadDir', payloadDir,
     '-RestartExe', restartExe,
     '-StageDir', path.dirname(helperPath),
+    '-RollbackDir', rollbackDir,
+    '-ResultPath', resultPath,
+    '-TargetVersion', String(version),
+    '-Flavor', flavor,
   ], { detached: true, stdio: 'ignore', windowsHide: true });
   child.unref();
   return { pid: child.pid, restartExe };
@@ -251,13 +424,24 @@ function createToolkitUpdateController(options = {}) {
   const codeRoot = options.codeRoot || path.join(__dirname, '..');
   const dataRoot = options.dataRoot || codeRoot;
   const currentVersion = options.currentVersion || require(path.join(codeRoot, 'package.json')).version;
-  const flavor = options.flavor || (platform === 'win32' ? windowsFlavor(codeRoot) : null);
+  const initialInstall = platform === 'win32' ? installationInfo(codeRoot, dataRoot) : null;
+  const flavor = options.flavor || (initialInstall ? initialInstall.edition : null);
+  const backendOwned = options.backendOwned === true;
+  const automaticInstallAllowed = platform !== 'win32' || (backendOwned && (options.flavor ? true : initialInstall.ok));
+  const manualInstallReason = platform !== 'win32'
+    ? null
+    : (!backendOwned
+      ? '当前窗口复用了已有本地服务，只能手动从 Release 更新，避免替换其他窗口正在使用的程序。'
+      : (initialInstall.ok ? null : initialInstall.error));
   const fetchFn = options.fetchFn || globalThis.fetch;
   const repository = options.repository || DEFAULT_REPOSITORY;
   const state = {
     state: 'idle', running: false, checked_at: null, current_version: currentVersion,
     version: null, available: false, platform: platform === 'darwin' ? 'macos' : 'windows',
     flavor, progress: null, error: null, update: null, download_path: null,
+    automatic_install: automaticInstallAllowed,
+    manual_install_reason: manualInstallReason,
+    last_result: readUpdateResult(dataRoot),
   };
   let inFlight = null;
 
@@ -268,11 +452,15 @@ function createToolkitUpdateController(options = {}) {
     try {
       const { release, version } = await fetchLatestRelease({ repository, fetchFn });
       const update = releaseSummary(release, version, currentVersion, platform, flavor);
+      if (platform === 'win32' && !automaticInstallAllowed) {
+        update.manual_only = true;
+        update.error = manualInstallReason || '当前安装不能自动替换，请从 Release 手动更新';
+      }
       state.checked_at = update.checked_at;
       state.version = version;
       state.available = update.available;
       state.update = update;
-      state.state = update.available ? (update.error ? 'incomplete' : 'available') : 'up-to-date';
+      state.state = update.available ? (update.manual_only ? 'manual-only' : (update.error ? 'incomplete' : 'available')) : 'up-to-date';
       state.error = update.error;
       return snapshot();
     } catch (error) {
@@ -290,9 +478,11 @@ function createToolkitUpdateController(options = {}) {
         current = state.update;
       }
       if (!current?.available) throw new Error('当前已是最新版本');
+      if (current.manual_only) throw new Error(current.error || '当前安装只能手动更新');
       if (current.error || !current.asset || !current.checksum) throw new Error(current.error || '当前版本缺少可验证的更新包');
       state.state = 'downloading'; state.running = true; state.error = null;
-      const stageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'typeless-toolkit-update-'));
+      cleanupStaging();
+      const stageDir = fs.mkdtempSync(path.join(os.tmpdir(), STAGING_PREFIX));
       const archivePath = path.join(stageDir, current.asset.name);
       try {
         const checksumResponse = await fetchFn(current.checksum.url, {
@@ -315,6 +505,7 @@ function createToolkitUpdateController(options = {}) {
         return snapshot();
       } catch (error) {
         try { fs.rmSync(stageDir, { recursive: true, force: true }); } catch (cleanupError) {}
+        state.download_path = null; state.stage_dir = null;
         throw error;
       }
     })();
@@ -325,19 +516,19 @@ function createToolkitUpdateController(options = {}) {
 
   function prepareWindowsInstall() {
     if (platform !== 'win32') throw new Error('工具集自动替换目前仅支持 Windows');
+    if (!backendOwned) throw new Error('当前窗口复用了已有本地服务，只能手动从 Release 更新');
     if (state.state !== 'downloaded' || !state.download_path || !state.stage_dir) {
       throw new Error('请先完成更新包下载和 SHA-256 校验');
     }
-    const installDir = path.resolve(codeRoot, '..');
-    const expectedDataDir = path.join(installDir, 'data');
-    if (path.resolve(dataRoot) !== path.resolve(expectedDataDir)) {
-      throw new Error('当前不是可安全更新的 Windows 发行版目录，请从 Release 手动更新');
-    }
+    const currentInstall = installationInfo(codeRoot, dataRoot);
+    if (!currentInstall.ok) throw new Error(currentInstall.error || '当前不是可安全更新的 Windows 发行版目录，请从 Release 手动更新');
+    if (currentInstall.edition !== state.flavor) throw new Error('当前 Windows 安装类型发生变化，请重新检查更新');
+    const installDir = currentInstall.install_dir;
     const extractionDir = path.join(state.stage_dir, 'payload');
     fs.mkdirSync(extractionDir, { recursive: true, mode: 0o700 });
     safeExtractZipWindows(state.download_path, extractionDir);
     const payloadDir = resolveWindowsPayloadRoot(extractionDir);
-    validateWindowsPayload(payloadDir);
+    validateWindowsPayload(payloadDir, state.version, state.flavor);
     const helperPath = writeWindowsUpdateHelper(state.stage_dir);
     const launched = launchWindowsUpdateHelper({
       parentPid: options.parentPid || process.pid,
@@ -345,24 +536,50 @@ function createToolkitUpdateController(options = {}) {
       installDir,
       payloadDir,
       helperPath,
+      version: state.version,
+      flavor: state.flavor,
     });
     state.state = 'installing';
     state.helper_pid = launched.pid;
     return { ...launched, version: state.version, preserve: 'data' };
   }
 
-  return { check, download, prepareWindowsInstall, status: snapshot };
+  function cleanupStaging() {
+    if (!state.stage_dir || state.state === 'installing') return;
+    try { fs.rmSync(state.stage_dir, { recursive: true, force: true }); } catch (error) {}
+    state.stage_dir = null;
+    state.download_path = null;
+    state.progress = null;
+  }
+
+  return { check, download, prepareWindowsInstall, cleanupStaging, status: snapshot };
+}
+
+function readUpdateResult(dataRoot) {
+  try {
+    const value = JSON.parse(fs.readFileSync(path.join(dataRoot, 'toolkit-update-result.json'), 'utf8'));
+    if (!['succeeded', 'rolled-back', 'failed'].includes(value?.state)) return null;
+    return {
+      state: value.state,
+      version: String(value.version || ''),
+      at: String(value.at || ''),
+      message: String(value.message || '').slice(0, 500),
+    };
+  } catch (error) { return null; }
 }
 
 module.exports = {
   DEFAULT_REPOSITORY,
   compareVersions,
   releaseVersion,
+  installationInfo,
   windowsFlavor,
   assetNames,
   findAsset,
   parseSha256File,
   isSafeZipEntry,
+  validateZipEntryMetadata,
+  validateZipMetadata,
   sha256File,
   downloadToFile,
   releaseSummary,
@@ -371,5 +588,6 @@ module.exports = {
   validateWindowsPayload,
   resolveWindowsPayloadRoot,
   writeWindowsUpdateHelper,
+  readUpdateResult,
   createToolkitUpdateController,
 };

--- a/lib/toolkit-update.js
+++ b/lib/toolkit-update.js
@@ -317,6 +317,7 @@ function writeWindowsUpdateHelper(stageDir) {
   [Parameter(Mandatory=$true)][string]$StageDir,
   [Parameter(Mandatory=$true)][string]$RollbackDir,
   [Parameter(Mandatory=$true)][string]$ResultPath,
+  [Parameter(Mandatory=$true)][string]$ReadyPath,
   [Parameter(Mandatory=$true)][string]$TargetVersion,
   [Parameter(Mandatory=$true)][string]$Flavor
 )
@@ -347,8 +348,11 @@ if ($install.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectoryS
 $payload = Assert-ChildPath $StageDir $PayloadDir
 $rollback = Assert-ChildPath $install $RollbackDir
 $result = Assert-ChildPath (Join-Path $install 'data') $ResultPath
+$ready = Assert-ChildPath $StageDir $ReadyPath
 if ((Split-Path -Leaf $rollback) -notmatch '^\.typeless-toolkit-update-rollback-[A-Za-z0-9]+$') { throw '临时回退目录名称无效。' }
+if ((Split-Path -Leaf $ready) -notmatch '^\.typeless-toolkit-ready-[A-Za-z0-9]+\.marker$') { throw '更新就绪标记名称无效。' }
 if (Test-Path -LiteralPath $rollback) { throw '临时回退目录已存在，请重试更新。' }
+if (Test-Path -LiteralPath $ready) { throw '更新就绪标记已存在，请重试更新。' }
 if ([IO.Path]::GetFullPath($RestartExe) -ne (Join-Path $install 'TypelessToolkit.exe')) { throw '重启程序路径无效。' }
 $deadline = (Get-Date).AddSeconds(75)
 $rollbackStarted = $false
@@ -375,9 +379,14 @@ try {
     Copy-Item -LiteralPath $_.FullName -Destination $install -Recurse -Force
   }
   Assert-Payload $install $TargetVersion $Flavor
-  $newProcess = Start-Process -FilePath $RestartExe -WorkingDirectory $install -PassThru
-  Start-Sleep -Seconds 4
-  if ($newProcess.HasExited) { throw "新版工具集启动失败，退出代码 $($newProcess.ExitCode)。" }
+  $newProcess = Start-Process -FilePath $RestartExe -WorkingDirectory $install -ArgumentList @('--toolkit-update-ready', $ready, '--toolkit-update-version', $TargetVersion) -PassThru
+  $readyDeadline = (Get-Date).AddSeconds(30)
+  while (!(Test-Path -LiteralPath $ready)) {
+    if ($newProcess.HasExited) { throw "新版工具集启动失败，退出代码 $($newProcess.ExitCode)。" }
+    if ((Get-Date) -gt $readyDeadline) { throw '新版工具集未完成版本就绪确认。' }
+    Start-Sleep -Milliseconds 250
+  }
+  if ((Get-Content -LiteralPath $ready -Raw).Trim() -ne $TargetVersion) { throw '新版工具集就绪标记版本不匹配。' }
   Remove-Item -LiteralPath $rollback -Recurse -Force
   Write-Result 'succeeded' "已更新到 v$TargetVersion。"
 } catch {
@@ -408,6 +417,7 @@ function launchWindowsUpdateHelper({ parentPid, hostPid, installDir, payloadDir,
   const restartExe = path.join(installDir, 'TypelessToolkit.exe');
   const rollbackDir = path.join(installDir, `.typeless-toolkit-update-rollback-${crypto.randomBytes(8).toString('hex')}`);
   const resultPath = path.join(installDir, 'data', 'toolkit-update-result.json');
+  const readyPath = path.join(path.dirname(helperPath), `.typeless-toolkit-ready-${crypto.randomBytes(8).toString('hex')}.marker`);
   const child = spawn('powershell.exe', [
     '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', helperPath,
     '-ParentPid', String(parentPid),
@@ -418,6 +428,7 @@ function launchWindowsUpdateHelper({ parentPid, hostPid, installDir, payloadDir,
     '-StageDir', path.dirname(helperPath),
     '-RollbackDir', rollbackDir,
     '-ResultPath', resultPath,
+    '-ReadyPath', readyPath,
     '-TargetVersion', String(version),
     '-Flavor', flavor,
   ], { detached: true, stdio: 'ignore', windowsHide: true });
@@ -532,9 +543,15 @@ function createToolkitUpdateController(options = {}) {
     const installDir = currentInstall.install_dir;
     const extractionDir = path.join(state.stage_dir, 'payload');
     fs.mkdirSync(extractionDir, { recursive: true, mode: 0o700 });
-    safeExtractZipWindows(state.download_path, extractionDir);
-    const payloadDir = resolveWindowsPayloadRoot(extractionDir);
-    validateWindowsPayload(payloadDir, state.version, state.flavor);
+    let payloadDir;
+    try {
+      safeExtractZipWindows(state.download_path, extractionDir);
+      payloadDir = resolveWindowsPayloadRoot(extractionDir);
+      validateWindowsPayload(payloadDir, state.version, state.flavor);
+    } catch (error) {
+      try { fs.rmSync(extractionDir, { recursive: true, force: true }); } catch (cleanupError) {}
+      throw error;
+    }
     const helperPath = writeWindowsUpdateHelper(state.stage_dir);
     const launched = launchWindowsUpdateHelper({
       parentPid: options.parentPid || process.pid,

--- a/lib/toolkit-update.js
+++ b/lib/toolkit-update.js
@@ -1,0 +1,375 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Readable } = require('stream');
+const { spawn, spawnSync } = require('child_process');
+
+const DEFAULT_REPOSITORY = 'Jia131313/typeless-toolkit';
+const MAX_RELEASE_DOWNLOAD_BYTES = 1024 * 1024 * 1024;
+
+function compareVersions(left, right) {
+  const parse = value => String(value || '')
+    .replace(/^v/i, '')
+    .split('-', 1)[0]
+    .split('.')
+    .map(part => Number.parseInt(part, 10) || 0);
+  const a = parse(left);
+  const b = parse(right);
+  const length = Math.max(a.length, b.length);
+  for (let index = 0; index < length; index++) {
+    const delta = (a[index] || 0) - (b[index] || 0);
+    if (delta) return delta > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+function releaseVersion(tagName) {
+  const match = String(tagName || '').match(/^v?(\d+(?:\.\d+){1,3})$/i);
+  return match ? match[1] : null;
+}
+
+function windowsFlavor(codeRoot) {
+  return fs.existsSync(path.join(codeRoot, '..', 'runtime', 'node.exe')) ? 'portable' : 'lite';
+}
+
+function assetNames(version, platform, flavor) {
+  if (platform === 'win32') {
+    const archive = `TypelessToolkit-v${version}-win-x64-${flavor}.zip`;
+    return { archive, checksum: `${archive}.sha256.txt` };
+  }
+  if (platform === 'darwin') {
+    const archive = `Typeless-Toolkit-${version}-universal.dmg`;
+    return { archive, checksum: `${archive}.sha256.txt` };
+  }
+  return null;
+}
+
+function findAsset(release, name) {
+  return (release && Array.isArray(release.assets) ? release.assets : [])
+    .find(asset => asset && asset.name === name) || null;
+}
+
+function parseSha256File(text, expectedFileName) {
+  const line = String(text || '').split(/\r?\n/).find(item => item.trim());
+  const match = line && line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+  if (!match) throw new Error('SHA-256 校验文件格式无效');
+  if (path.basename(match[2].trim()) !== expectedFileName) {
+    throw new Error('SHA-256 校验文件与下载包不匹配');
+  }
+  return match[1].toLowerCase();
+}
+
+function isSafeZipEntry(name) {
+  const normalized = String(name || '').replace(/\\/g, '/');
+  return !!normalized &&
+    !normalized.startsWith('/') &&
+    !/^[A-Za-z]:\//.test(normalized) &&
+    !normalized.split('/').includes('..');
+}
+
+async function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  await new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  return hash.digest('hex');
+}
+
+async function downloadToFile(url, filePath, options = {}) {
+  const fetchFn = options.fetchFn || globalThis.fetch;
+  const onProgress = options.onProgress || (() => {});
+  const maxBytes = options.maxBytes || MAX_RELEASE_DOWNLOAD_BYTES;
+  const response = await fetchFn(url, {
+    headers: { 'User-Agent': 'typeless-toolkit-updater' },
+    redirect: 'follow',
+  });
+  if (!response.ok || !response.body) throw new Error(`下载更新包失败: HTTP ${response.status}`);
+  const total = Number(response.headers?.get?.('content-length') || 0);
+  if (total && total > maxBytes) throw new Error('更新包大小超出安全上限');
+  const output = fs.createWriteStream(filePath, { flags: 'w', mode: 0o600 });
+  let downloaded = 0;
+  const body = Readable.fromWeb(response.body);
+  try {
+    for await (const chunk of body) {
+      downloaded += chunk.length;
+      if (downloaded > maxBytes) throw new Error('更新包大小超出安全上限');
+      if (!output.write(chunk)) await new Promise(resolve => output.once('drain', resolve));
+      onProgress(downloaded, total);
+    }
+    await new Promise((resolve, reject) => output.end(error => error ? reject(error) : resolve()));
+  } catch (error) {
+    output.destroy();
+    try { fs.unlinkSync(filePath); } catch (unlinkError) {}
+    throw error;
+  }
+  return { downloaded, total };
+}
+
+function releaseSummary(release, version, currentVersion, platform, flavor) {
+  const names = assetNames(version, platform, flavor);
+  const archive = names && findAsset(release, names.archive);
+  const checksum = names && findAsset(release, names.checksum);
+  return {
+    checked_at: new Date().toISOString(),
+    current_version: currentVersion,
+    version,
+    available: compareVersions(version, currentVersion) > 0,
+    release_url: release.html_url || null,
+    published_at: release.published_at || null,
+    notes: String(release.body || ''),
+    platform: platform === 'darwin' ? 'macos' : 'windows',
+    flavor: platform === 'win32' ? flavor : null,
+    asset: archive ? {
+      name: archive.name,
+      url: archive.browser_download_url,
+      size: archive.size || 0,
+    } : null,
+    checksum: checksum ? {
+      name: checksum.name,
+      url: checksum.browser_download_url,
+    } : null,
+    error: archive && checksum ? null : `该版本未提供当前平台所需的更新包或 SHA-256 校验文件（需要 ${names.archive} 与 ${names.checksum}）`,
+  };
+}
+
+async function fetchLatestRelease(options = {}) {
+  const repository = options.repository || DEFAULT_REPOSITORY;
+  const fetchFn = options.fetchFn || globalThis.fetch;
+  const response = await fetchFn(`https://api.github.com/repos/${repository}/releases/latest`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'typeless-toolkit-updater',
+    },
+  });
+  if (!response.ok) throw new Error(`检查 GitHub Release 失败: HTTP ${response.status}`);
+  const release = await response.json();
+  const version = releaseVersion(release.tag_name);
+  if (!version) throw new Error('最新 Release 的标签不是受支持的版本号');
+  return { release, version };
+}
+
+function powershell(command, args, options = {}) {
+  const executable = options.executable || 'powershell.exe';
+  const result = spawnSync(executable, [
+    '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+    '-Command', command,
+    ...args,
+  ], { encoding: 'utf8', windowsHide: true });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error((result.stderr || result.stdout || 'PowerShell 执行失败').trim());
+}
+
+function safeExtractZipWindows(zipPath, outputDir, options = {}) {
+  const script = [
+    '$ErrorActionPreference = "Stop"',
+    'Add-Type -AssemblyName System.IO.Compression.FileSystem',
+    '$zip = [System.IO.Compression.ZipFile]::OpenRead($args[0])',
+    'try {',
+    '  foreach ($entry in $zip.Entries) {',
+    '    $name = $entry.FullName.Replace("\\", "/")',
+    '    if (!$name -or $name.StartsWith("/") -or $name -match "^[A-Za-z]:/" -or $name.Split("/") -contains "..") { throw "更新包包含不安全路径: $name" }',
+    '  }',
+    '} finally { $zip.Dispose() }',
+    '[System.IO.Compression.ZipFile]::ExtractToDirectory($args[0], $args[1])',
+  ].join('; ');
+  powershell(script, [zipPath, outputDir], options);
+}
+
+function validateWindowsPayload(payloadDir) {
+  const executable = path.join(payloadDir, 'TypelessToolkit.exe');
+  const manager = path.join(payloadDir, 'server', 'manager.js');
+  if (!fs.existsSync(executable) || !fs.existsSync(manager)) {
+    throw new Error('更新包内容不完整，未找到启动器或本地服务');
+  }
+}
+
+function resolveWindowsPayloadRoot(extractedDir) {
+  if (fs.existsSync(path.join(extractedDir, 'TypelessToolkit.exe'))) return extractedDir;
+  const children = fs.readdirSync(extractedDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory());
+  if (children.length === 1) {
+    const nested = path.join(extractedDir, children[0].name);
+    if (fs.existsSync(path.join(nested, 'TypelessToolkit.exe'))) return nested;
+  }
+  throw new Error('更新包目录结构不符合预期');
+}
+
+function writeWindowsUpdateHelper(stageDir) {
+  const helperPath = path.join(stageDir, 'apply-update.ps1');
+  const script = String.raw`param(
+  [Parameter(Mandatory=$true)][int]$ParentPid,
+  [Parameter(Mandatory=$true)][int]$HostPid,
+  [Parameter(Mandatory=$true)][string]$InstallDir,
+  [Parameter(Mandatory=$true)][string]$PayloadDir,
+  [Parameter(Mandatory=$true)][string]$RestartExe,
+  [Parameter(Mandatory=$true)][string]$StageDir
+)
+$ErrorActionPreference = 'Stop'
+$deadline = (Get-Date).AddSeconds(75)
+while ((Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) -or (Get-Process -Id $HostPid -ErrorAction SilentlyContinue)) {
+  if ((Get-Date) -gt $deadline) { throw '旧版工具集未在 75 秒内退出；请手动退出后重试。' }
+  Start-Sleep -Milliseconds 250
+}
+if (!(Test-Path -LiteralPath (Join-Path $PayloadDir 'TypelessToolkit.exe')) -or !(Test-Path -LiteralPath (Join-Path $PayloadDir 'server\manager.js'))) {
+  throw '更新包内容不完整，已取消替换。'
+}
+Get-ChildItem -LiteralPath $InstallDir -Force | Where-Object { $_.Name -ne 'data' } | ForEach-Object {
+  Remove-Item -LiteralPath $_.FullName -Recurse -Force
+}
+Get-ChildItem -LiteralPath $PayloadDir -Force | ForEach-Object {
+  if ($_.Name -ne 'data') { Copy-Item -LiteralPath $_.FullName -Destination $InstallDir -Recurse -Force }
+}
+Start-Process -FilePath $RestartExe -WorkingDirectory $InstallDir
+$cleanup = 'timeout /t 5 /nobreak >nul & rmdir /s /q "' + $StageDir + '"'
+Start-Process -FilePath $env:ComSpec -ArgumentList '/d', '/c', $cleanup -WindowStyle Hidden
+`;
+  fs.writeFileSync(helperPath, script, { encoding: 'utf8', mode: 0o600 });
+  return helperPath;
+}
+
+function launchWindowsUpdateHelper({ parentPid, hostPid, installDir, payloadDir, helperPath }) {
+  const restartExe = path.join(installDir, 'TypelessToolkit.exe');
+  const child = spawn('powershell.exe', [
+    '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', helperPath,
+    '-ParentPid', String(parentPid),
+    '-HostPid', String(hostPid || parentPid),
+    '-InstallDir', installDir,
+    '-PayloadDir', payloadDir,
+    '-RestartExe', restartExe,
+    '-StageDir', path.dirname(helperPath),
+  ], { detached: true, stdio: 'ignore', windowsHide: true });
+  child.unref();
+  return { pid: child.pid, restartExe };
+}
+
+function createToolkitUpdateController(options = {}) {
+  const platform = options.platform || process.platform;
+  const codeRoot = options.codeRoot || path.join(__dirname, '..');
+  const dataRoot = options.dataRoot || codeRoot;
+  const currentVersion = options.currentVersion || require(path.join(codeRoot, 'package.json')).version;
+  const flavor = options.flavor || (platform === 'win32' ? windowsFlavor(codeRoot) : null);
+  const fetchFn = options.fetchFn || globalThis.fetch;
+  const repository = options.repository || DEFAULT_REPOSITORY;
+  const state = {
+    state: 'idle', running: false, checked_at: null, current_version: currentVersion,
+    version: null, available: false, platform: platform === 'darwin' ? 'macos' : 'windows',
+    flavor, progress: null, error: null, update: null, download_path: null,
+  };
+  let inFlight = null;
+
+  const snapshot = () => JSON.parse(JSON.stringify(state));
+
+  async function check() {
+    state.state = 'checking'; state.running = true; state.error = null;
+    try {
+      const { release, version } = await fetchLatestRelease({ repository, fetchFn });
+      const update = releaseSummary(release, version, currentVersion, platform, flavor);
+      state.checked_at = update.checked_at;
+      state.version = version;
+      state.available = update.available;
+      state.update = update;
+      state.state = update.available ? (update.error ? 'incomplete' : 'available') : 'up-to-date';
+      state.error = update.error;
+      return snapshot();
+    } catch (error) {
+      state.state = 'error'; state.error = error.message; state.update = null;
+      throw error;
+    } finally { state.running = false; }
+  }
+
+  async function download() {
+    if (inFlight) return snapshot();
+    inFlight = (async () => {
+      let current = state.update;
+      if (!current || !current.available) {
+        await check();
+        current = state.update;
+      }
+      if (!current?.available) throw new Error('当前已是最新版本');
+      if (current.error || !current.asset || !current.checksum) throw new Error(current.error || '当前版本缺少可验证的更新包');
+      state.state = 'downloading'; state.running = true; state.error = null;
+      const stageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'typeless-toolkit-update-'));
+      const archivePath = path.join(stageDir, current.asset.name);
+      try {
+        const checksumResponse = await fetchFn(current.checksum.url, {
+          headers: { 'User-Agent': 'typeless-toolkit-updater' }, redirect: 'follow',
+        });
+        if (!checksumResponse.ok) throw new Error(`下载 SHA-256 校验文件失败: HTTP ${checksumResponse.status}`);
+        const expectedHash = parseSha256File(await checksumResponse.text(), current.asset.name);
+        await downloadToFile(current.asset.url, archivePath, {
+          fetchFn,
+          onProgress(downloaded, total) {
+            state.progress = { downloaded, total, percent: total ? Math.floor(downloaded * 100 / total) : null };
+          },
+        });
+        const actualHash = await sha256File(archivePath);
+        if (actualHash !== expectedHash) throw new Error('更新包 SHA-256 校验失败，已取消安装');
+        state.download_path = archivePath;
+        state.stage_dir = stageDir;
+        state.state = 'downloaded';
+        state.progress = { ...(state.progress || {}), percent: 100 };
+        return snapshot();
+      } catch (error) {
+        try { fs.rmSync(stageDir, { recursive: true, force: true }); } catch (cleanupError) {}
+        throw error;
+      }
+    })();
+    try { return await inFlight; }
+    catch (error) { state.state = 'error'; state.error = error.message; throw error; }
+    finally { state.running = false; inFlight = null; }
+  }
+
+  function prepareWindowsInstall() {
+    if (platform !== 'win32') throw new Error('工具集自动替换目前仅支持 Windows');
+    if (state.state !== 'downloaded' || !state.download_path || !state.stage_dir) {
+      throw new Error('请先完成更新包下载和 SHA-256 校验');
+    }
+    const installDir = path.resolve(codeRoot, '..');
+    const expectedDataDir = path.join(installDir, 'data');
+    if (path.resolve(dataRoot) !== path.resolve(expectedDataDir)) {
+      throw new Error('当前不是可安全更新的 Windows 发行版目录，请从 Release 手动更新');
+    }
+    const extractionDir = path.join(state.stage_dir, 'payload');
+    fs.mkdirSync(extractionDir, { recursive: true, mode: 0o700 });
+    safeExtractZipWindows(state.download_path, extractionDir);
+    const payloadDir = resolveWindowsPayloadRoot(extractionDir);
+    validateWindowsPayload(payloadDir);
+    const helperPath = writeWindowsUpdateHelper(state.stage_dir);
+    const launched = launchWindowsUpdateHelper({
+      parentPid: options.parentPid || process.pid,
+      hostPid: options.hostPid || options.parentPid || process.pid,
+      installDir,
+      payloadDir,
+      helperPath,
+    });
+    state.state = 'installing';
+    state.helper_pid = launched.pid;
+    return { ...launched, version: state.version, preserve: 'data' };
+  }
+
+  return { check, download, prepareWindowsInstall, status: snapshot };
+}
+
+module.exports = {
+  DEFAULT_REPOSITORY,
+  compareVersions,
+  releaseVersion,
+  windowsFlavor,
+  assetNames,
+  findAsset,
+  parseSha256File,
+  isSafeZipEntry,
+  sha256File,
+  downloadToFile,
+  releaseSummary,
+  fetchLatestRelease,
+  safeExtractZipWindows,
+  validateWindowsPayload,
+  resolveWindowsPayloadRoot,
+  writeWindowsUpdateHelper,
+  createToolkitUpdateController,
+};

--- a/main.cs
+++ b/main.cs
@@ -53,12 +53,15 @@ class TrayApp
     static string backendError;
     static bool exiting;
     static bool backendReused;
+    static string updateReadyPath;
+    static string updateTargetVersion;
 
     [STAThread]
-    static void Main()
+    static void Main(string[] args)
     {
         // 让 WinForms 与 WebView2 使用相同的物理 DPI，避免系统位图缩放造成页面发糊。
         try { SetProcessDpiAwarenessContext(new IntPtr(-4)); } catch { }
+        ParseUpdateReadyArguments(args);
 
         bool createdNew;
         singleInstance = new Mutex(true, "TypelessToolkit.Desktop.SingleInstance", out createdNew);
@@ -87,6 +90,12 @@ class TrayApp
             return;
         }
 
+        if (!string.IsNullOrEmpty(updateReadyPath) && !SignalUpdateReady())
+        {
+            Cleanup();
+            return;
+        }
+
         BuildTray();
         string pageUrl = baseUrl + (backendReused ? "/?toolkit_backend=shared" : "/");
         managerForm = new ManagerForm(pageUrl, exeDir, LoadAppIcon());
@@ -103,6 +112,55 @@ class TrayApp
             ShowWindow(window, SW_RESTORE);
             SetForegroundWindow(window);
         }
+    }
+
+    static void ParseUpdateReadyArguments(string[] args)
+    {
+        if (args == null) return;
+        for (int i = 0; i + 1 < args.Length; i++)
+        {
+            if (args[i] == "--toolkit-update-ready") updateReadyPath = args[++i];
+            else if (args[i] == "--toolkit-update-version") updateTargetVersion = args[++i];
+        }
+        if (string.IsNullOrEmpty(updateReadyPath) || string.IsNullOrEmpty(updateTargetVersion))
+        {
+            updateReadyPath = null;
+            updateTargetVersion = null;
+            return;
+        }
+        try
+        {
+            string marker = Path.GetFullPath(updateReadyPath);
+            string stage = Path.GetDirectoryName(marker);
+            string tempRoot = Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (stage == null || Path.GetDirectoryName(stage) == null ||
+                !string.Equals(Path.GetDirectoryName(stage).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), tempRoot, StringComparison.OrdinalIgnoreCase) ||
+                !Path.GetFileName(stage).StartsWith("typeless-toolkit-update-", StringComparison.OrdinalIgnoreCase) ||
+                !Regex.IsMatch(Path.GetFileName(marker), "^\\.typeless-toolkit-ready-[A-Za-z0-9]+\\.marker$") ||
+                !Regex.IsMatch(updateTargetVersion, "^\\d+(?:\\.\\d+){1,3}$"))
+            {
+                updateReadyPath = null;
+                updateTargetVersion = null;
+                return;
+            }
+            updateReadyPath = marker;
+        }
+        catch
+        {
+            updateReadyPath = null;
+            updateTargetVersion = null;
+        }
+    }
+
+    static bool SignalUpdateReady()
+    {
+        try
+        {
+            if (!ProbeToolkit(updateTargetVersion)) return false;
+            File.WriteAllText(updateReadyPath, updateTargetVersion + Environment.NewLine);
+            return true;
+        }
+        catch { return false; }
     }
 
     static bool EnsureBackend()
@@ -275,7 +333,7 @@ class TrayApp
         return 7788;
     }
 
-    static bool ProbeToolkit()
+    static bool ProbeToolkit(string expectedVersion = null)
     {
         try
         {
@@ -287,9 +345,14 @@ class TrayApp
             using (StreamReader reader = new StreamReader(response.GetResponseStream()))
             {
                 string body = reader.ReadToEnd();
-                return response.StatusCode == HttpStatusCode.OK &&
+                bool valid = response.StatusCode == HttpStatusCode.OK &&
                     body.IndexOf("\"status\":\"OK\"", StringComparison.Ordinal) >= 0 &&
                     body.IndexOf("\"service\":\"typeless-toolkit\"", StringComparison.Ordinal) >= 0;
+                if (!valid) return false;
+                return string.IsNullOrEmpty(expectedVersion) || Regex.IsMatch(
+                    body,
+                    "\\\"toolkit_version\\\"\\s*:\\s*\\\"" + Regex.Escape(expectedVersion) + "\\\""
+                );
             }
         }
         catch { return false; }

--- a/main.cs
+++ b/main.cs
@@ -154,6 +154,7 @@ class TrayApp
         nodeProcess.StartInfo.RedirectStandardError = true;
         nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_DATA_DIR"] = dataDir;
         nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_MANAGER_PORT"] = managerPort.ToString();
+        nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_TOOLKIT_HOST_PID"] = Process.GetCurrentProcess().Id.ToString();
 
         try { nodeProcess.Start(); }
         catch (Exception error)
@@ -380,6 +381,13 @@ class TrayApp
 
     static void ExitApplication()
     {
+        ExitForToolkitUpdate();
+    }
+
+    // Windows 自更新 helper 已在临时目录启动后，界面通过 WebView2 请求完整退出。
+    // Cleanup 会结束由本宿主启动的 Node 服务；helper 随后才替换程序文件。
+    internal static void ExitForToolkitUpdate()
+    {
         exiting = true;
         if (managerForm != null) managerForm.Close();
         Application.Exit();
@@ -496,6 +504,7 @@ class ManagerForm : Form
                     string message = args.TryGetWebMessageAsString();
                     if (message == "theme:dark") ApplyTitleBarTheme(true);
                     else if (message == "theme:light") ApplyTitleBarTheme(false);
+                    else if (message == "toolkit-update:quit") TrayApp.ExitForToolkitUpdate();
                 }
                 catch { }
             };

--- a/main.cs
+++ b/main.cs
@@ -52,6 +52,7 @@ class TrayApp
     static string baseUrl;
     static string backendError;
     static bool exiting;
+    static bool backendReused;
 
     [STAThread]
     static void Main()
@@ -87,7 +88,8 @@ class TrayApp
         }
 
         BuildTray();
-        managerForm = new ManagerForm(baseUrl, exeDir, LoadAppIcon());
+        string pageUrl = baseUrl + (backendReused ? "/?toolkit_backend=shared" : "/");
+        managerForm = new ManagerForm(pageUrl, exeDir, LoadAppIcon());
         managerForm.FormClosing += OnManagerFormClosing;
         Application.Run(managerForm);
         Cleanup();
@@ -107,7 +109,11 @@ class TrayApp
     {
         if (IsPortOpen())
         {
-            if (ProbeToolkit()) return true;
+            if (ProbeToolkit())
+            {
+                backendReused = true;
+                return true;
+            }
             int occupiedPort = managerPort;
             if (!UseFallbackPort())
             {
@@ -155,6 +161,8 @@ class TrayApp
         nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_DATA_DIR"] = dataDir;
         nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_MANAGER_PORT"] = managerPort.ToString();
         nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_TOOLKIT_HOST_PID"] = Process.GetCurrentProcess().Id.ToString();
+        nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_TOOLKIT_BACKEND_OWNER"] = "desktop-host";
+        nodeProcess.StartInfo.EnvironmentVariables["TYPELESS_TOOLKIT_INSTALL_DIR"] = exeDir;
 
         try { nodeProcess.Start(); }
         catch (Exception error)

--- a/manager.html
+++ b/manager.html
@@ -495,6 +495,7 @@ let ACCOUNTS = [], CUR_ID = null, curDetail = null, curWords = [], captureBusy =
 let DICT_SYNC_STATUS = null, MASTER_ORIGINAL = [];
 let ENV_INFO = null, PAYWALL_MAINTENANCE = null, PAYWALL_NOTICE_AT = null, PENDING_MAC_ACTION = null, PAYWALL_SETTINGS_OPENED = false, PAYWALL_FOCUS_RETRY_BUSY = false;
 let TOOLKIT_UPDATE = null, TOOLKIT_UPDATE_POLL = null, TOOLKIT_UPDATE_NOTIFIED = false;
+const TOOLKIT_UPDATE_SHARED_BACKEND = new URLSearchParams(window.location.search).get('toolkit_backend') === 'shared';
 let SC_STATE = { features: [], bindings: {}, max_parts: 2, recordingId: null, draft: {} };
 const SC_CODE_MAP = {
   ControlLeft:'LeftCtrl', ControlRight:'RightCtrl',
@@ -1077,7 +1078,12 @@ function renderToolkitUpdate(){
   summary.textContent=`发现 Typeless 工具集 v${d.version}（当前 v${d.current_version}）`;
   notes.textContent=u?.notes||'该版本未提供更新说明。'; notes.style.display='';
   if(release) release.style.display=u?.release_url?'':'none';
-  if(d.state==='downloading'){
+  if(u?.manual_only || TOOLKIT_UPDATE_SHARED_BACKEND){
+    progress.textContent=TOOLKIT_UPDATE_SHARED_BACKEND
+      ? '此窗口复用了其他工具集的本地服务，为避免替换仍在使用的程序，请从 Release 手动更新。'
+      : (u.error||d.manual_install_reason||'当前安装只能手动更新。');
+    action.textContent='前往 Release 手动更新'; action.disabled=!u.release_url;
+  }else if(d.state==='downloading'){
     const p=d.progress||{};
     progress.textContent=p.total
       ? `正在下载并校验：${updateBytes(p.downloaded)} / ${updateBytes(p.total)}（${p.percent||0}%）`
@@ -1094,9 +1100,10 @@ function renderToolkitUpdate(){
     action.textContent=d.state==='error'?'重新下载':'下载更新'; action.disabled=false;
   }
   if(boundary){
-    boundary.textContent=d.platform==='macos'
+    const result=d.last_result?.message ? `上次更新：${d.last_result.message}` : '';
+    boundary.textContent=(d.platform==='macos'
       ? 'macOS 当前采用 ad-hoc 签名：这里只会校验下载并打开 DMG，仍需你将 App 拖入“应用程序”完成替换。'
-      : 'Windows 会在退出当前工具集后由独立更新程序替换代码文件，并明确保留 data 目录。';
+      : ((u?.manual_only || TOOLKIT_UPDATE_SHARED_BACKEND) ? (u?.error||d.manual_install_reason||'当前安装只能手动更新。') : 'Windows 会在退出当前工具集后由独立更新程序替换代码文件，并明确保留 data 目录。')) + (result?`\n${result}`:'');
   }
 }
 async function refreshToolkitUpdate(announce=false){
@@ -1136,6 +1143,7 @@ function openToolkitUpdateRelease(){
 async function downloadToolkitUpdate(){
   const d=TOOLKIT_UPDATE;
   if(!d?.available){ await refreshToolkitUpdate(false); return; }
+  if(d.update?.manual_only || TOOLKIT_UPDATE_SHARED_BACKEND){ openToolkitUpdateRelease(); toast(d.update?.error||'当前安装只能手动更新','err'); return; }
   if(d.state==='downloaded'){
     if(d.platform==='macos'){
       const result=await window.typelessToolkitDesktop?.openToolkitUpdateFile?.(d.download_path);

--- a/manager.html
+++ b/manager.html
@@ -194,7 +194,7 @@
   a.link { color:var(--accent); cursor:pointer; text-decoration:none; }
   a.link:hover { text-decoration:underline; }
   @media (max-width:960px){ .stats{grid-template-columns:repeat(2,1fr)} }
-  @media (max-width:1080px){
+  @media (max-width:1280px){
     .toolbar { flex-wrap:wrap; gap:8px; }
     .tool-group { flex-wrap:wrap; }
     .tool-group.primary-tools { flex:1 1 100%; }

--- a/manager.html
+++ b/manager.html
@@ -244,7 +244,8 @@
       <button class="btn" onclick="openMaster()" title="查看和编辑跨账号同步使用的主词库">✎ 主词库</button>
       <button class="btn" onclick="backup()" title="备份账号清单和主词库数据">⇩ 备份</button>
       <button class="btn" onclick="openShortcuts()" title="管理 Typeless 功能快捷键">⌨ 快捷键</button>
-      <button class="btn" id="officialUpdateBtn" style="display:none" onclick="installOfficialUpdate()">⬆ 官方更新</button>
+      <button class="btn" id="toolkitUpdateBtn" onclick="openToolkitUpdate()" title="检查 Typeless 工具集是否有新版本">⬆ 工具集更新</button>
+      <button class="btn" id="officialUpdateBtn" style="display:none" onclick="installOfficialUpdate()">⬆ 安装 Typeless 官方更新</button>
     </div>
     <div class="tool-group system-tools">
       <button class="btn" id="macPermissionBtn" style="display:none" onclick="openMacPermissionGuide()" title="查看 Typeless 与工具集各自需要的 macOS 权限和修复方式">🔐 macOS 权限</button>
@@ -465,6 +466,22 @@
   </div>
 </div>
 
+<div class="mask" id="toolkitUpdateMask" onclick="if(event.target===this)closeModal('toolkitUpdateMask')">
+  <div class="modal" style="width:min(650px,94vw)">
+    <div class="hd"><h3>Typeless 工具集更新</h3><button class="icon-btn" onclick="closeModal('toolkitUpdateMask')">✕</button></div>
+    <div class="bd">
+      <div id="toolkitUpdateSummary" class="permission-intro">正在检查 GitHub Release…</div>
+      <div id="toolkitUpdateProgress" class="hint" style="margin-top:10px"></div>
+      <pre id="toolkitUpdateNotes" class="hint" style="display:none;max-height:250px;overflow:auto;white-space:pre-wrap;word-break:break-word;margin:14px 0 0;padding:12px;border-radius:10px"></pre>
+      <div class="row-btns" style="margin-top:14px">
+        <button class="btn primary" id="toolkitUpdateActionBtn" onclick="downloadToolkitUpdate()">检查更新</button>
+        <button class="btn" id="toolkitUpdateReleaseBtn" onclick="openToolkitUpdateRelease()" style="display:none">查看 Release</button>
+      </div>
+      <div class="hint" id="toolkitUpdateBoundary" style="margin-top:12px"></div>
+    </div>
+  </div>
+</div>
+
 <div class="toast" id="toast"></div>
 
 <script>
@@ -477,6 +494,7 @@ async function apiTimed(p,opt={},timeoutMs=30000){
 let ACCOUNTS = [], CUR_ID = null, curDetail = null, curWords = [], captureBusy = false, currentBusy = false;
 let DICT_SYNC_STATUS = null, MASTER_ORIGINAL = [];
 let ENV_INFO = null, PAYWALL_MAINTENANCE = null, PAYWALL_NOTICE_AT = null, PENDING_MAC_ACTION = null, PAYWALL_SETTINGS_OPENED = false, PAYWALL_FOCUS_RETRY_BUSY = false;
+let TOOLKIT_UPDATE = null, TOOLKIT_UPDATE_POLL = null, TOOLKIT_UPDATE_NOTIFIED = false;
 let SC_STATE = { features: [], bindings: {}, max_parts: 2, recordingId: null, draft: {} };
 const SC_CODE_MAP = {
   ControlLeft:'LeftCtrl', ControlRight:'RightCtrl',
@@ -1010,9 +1028,133 @@ async function refreshOfficialUpdate(){
     btn.style.display='';
     const localPackageNote='仅安装 Typeless updater 已下载的本地缓存包，不更新 Typeless Toolkit。';
     btn.classList.remove('primary');
-    if(d.available){ btn.disabled=false; btn.textContent='⬆ 官方更新'; btn.title='可安装 Typeless '+d.pending.version+'：'+d.pending.fileName+'\n'+localPackageNote; }
-    else { btn.disabled=false; btn.textContent='⬆ 官方更新'; btn.title=(d.reason||'未发现可安装更新')+'\n'+localPackageNote; }
+    if(d.available){ btn.disabled=false; btn.textContent='⬆ 安装 Typeless 官方更新'; btn.title='可安装 Typeless '+d.pending.version+'：'+d.pending.fileName+'\n'+localPackageNote; }
+    else { btn.disabled=false; btn.textContent='⬆ 安装 Typeless 官方更新'; btn.title=(d.reason||'未发现可安装更新')+'\n'+localPackageNote; }
   }catch(e){ btn.disabled=false; btn.title='Typeless 官方更新状态读取失败'; }
+}
+
+function updateBytes(value){
+  const bytes=Number(value||0);
+  if(!bytes) return '已下载';
+  if(bytes<1024*1024) return (bytes/1024).toFixed(1)+' KB';
+  return (bytes/1024/1024).toFixed(1)+' MB';
+}
+function renderToolkitUpdate(){
+  const btn=document.getElementById('toolkitUpdateBtn');
+  const d=TOOLKIT_UPDATE, u=d?.update;
+  if(btn){
+    btn.disabled=!!d?.running;
+    if(d?.running) btn.textContent='⬆ 工具集更新中…';
+    else if(d?.available) btn.textContent='⬆ 工具集 v'+d.version;
+    else btn.textContent='⬆ 工具集更新';
+    btn.title=d?.available
+      ? `发现 Typeless 工具集 ${d.version}，点击查看更新说明`
+      : (d?.error||'检查 Typeless 工具集的新版本');
+  }
+  const summary=document.getElementById('toolkitUpdateSummary');
+  const progress=document.getElementById('toolkitUpdateProgress');
+  const notes=document.getElementById('toolkitUpdateNotes');
+  const action=document.getElementById('toolkitUpdateActionBtn');
+  const release=document.getElementById('toolkitUpdateReleaseBtn');
+  const boundary=document.getElementById('toolkitUpdateBoundary');
+  if(!summary||!action) return;
+  if(!d){
+    summary.textContent='正在检查 GitHub Release…'; action.textContent='检查更新'; action.disabled=true;
+    progress.textContent=''; notes.style.display='none'; release.style.display='none'; return;
+  }
+  if(d.error && !u){
+    summary.textContent='检查更新失败：'+d.error; action.textContent='重试检查'; action.disabled=false;
+    progress.textContent=''; notes.style.display='none'; release.style.display='none'; return;
+  }
+  if(!d.available){
+    summary.textContent='当前已是最新版本 v'+(d.current_version||'');
+    action.textContent='重新检查'; action.disabled=!!d.running;
+    progress.textContent=d.error||''; notes.style.display='none'; release.style.display=u?.release_url?'':'none';
+    if(release) release.style.display=u?.release_url?'':'none';
+    if(boundary) boundary.textContent='更新检查只读取 GitHub Release 元数据，不会读取账号、词库或配置。';
+    return;
+  }
+  summary.textContent=`发现 Typeless 工具集 v${d.version}（当前 v${d.current_version}）`;
+  notes.textContent=u?.notes||'该版本未提供更新说明。'; notes.style.display='';
+  if(release) release.style.display=u?.release_url?'':'none';
+  if(d.state==='downloading'){
+    const p=d.progress||{};
+    progress.textContent=p.total
+      ? `正在下载并校验：${updateBytes(p.downloaded)} / ${updateBytes(p.total)}（${p.percent||0}%）`
+      : `正在下载并校验：${updateBytes(p.downloaded)}`;
+    action.textContent='下载中…'; action.disabled=true;
+  }else if(d.state==='downloaded'){
+    progress.textContent='更新包 SHA-256 校验通过。';
+    action.textContent=d.platform==='windows'?'退出并安装更新':'打开已下载的 DMG'; action.disabled=false;
+  }else if(d.state==='installing'){
+    progress.textContent='即将退出当前窗口并替换程序文件；账号、快照、词库和配置不会被覆盖。';
+    action.textContent='正在安装…'; action.disabled=true;
+  }else {
+    progress.textContent=d.error||'';
+    action.textContent=d.state==='error'?'重新下载':'下载更新'; action.disabled=false;
+  }
+  if(boundary){
+    boundary.textContent=d.platform==='macos'
+      ? 'macOS 当前采用 ad-hoc 签名：这里只会校验下载并打开 DMG，仍需你将 App 拖入“应用程序”完成替换。'
+      : 'Windows 会在退出当前工具集后由独立更新程序替换代码文件，并明确保留 data 目录。';
+  }
+}
+async function refreshToolkitUpdate(announce=false){
+  try{
+    const r=await apiTimed('/api/toolkit-update',{},25000);
+    if(r.status!=='OK') throw new Error(r.msg||'检查失败');
+    TOOLKIT_UPDATE=r.data||null;
+    if(announce && TOOLKIT_UPDATE?.available&&!TOOLKIT_UPDATE_NOTIFIED){
+      TOOLKIT_UPDATE_NOTIFIED=true;
+      toast('发现 Typeless 工具集 v'+TOOLKIT_UPDATE.version+'，点击“工具集更新”查看','ok');
+    }
+  }catch(e){
+    TOOLKIT_UPDATE={state:'error',running:false,error:e.message||'检查更新失败'};
+  }
+  renderToolkitUpdate();
+  return TOOLKIT_UPDATE;
+}
+function startToolkitUpdatePoll(){
+  if(TOOLKIT_UPDATE_POLL) clearInterval(TOOLKIT_UPDATE_POLL);
+  TOOLKIT_UPDATE_POLL=setInterval(async()=>{
+    try{
+      const r=await api('/api/toolkit-update/status');
+      if(r.status!=='OK') return;
+      TOOLKIT_UPDATE=r.data||TOOLKIT_UPDATE; renderToolkitUpdate();
+      if(!TOOLKIT_UPDATE?.running){ clearInterval(TOOLKIT_UPDATE_POLL); TOOLKIT_UPDATE_POLL=null; }
+    }catch(e){}
+  },500);
+}
+async function openToolkitUpdate(){
+  if(!TOOLKIT_UPDATE||TOOLKIT_UPDATE.state==='error') await refreshToolkitUpdate(false);
+  renderToolkitUpdate(); openModal('toolkitUpdateMask');
+}
+function openToolkitUpdateRelease(){
+  const url=TOOLKIT_UPDATE?.update?.release_url;
+  if(url) window.open(url,'_blank');
+}
+async function downloadToolkitUpdate(){
+  const d=TOOLKIT_UPDATE;
+  if(!d?.available){ await refreshToolkitUpdate(false); return; }
+  if(d.state==='downloaded'){
+    if(d.platform==='macos'){
+      const result=await window.typelessToolkitDesktop?.openToolkitUpdateFile?.(d.download_path);
+      if(result?.ok) toast('已在 Finder 中打开 DMG，请拖入“应用程序”完成替换','ok');
+      else toast(result?.message||'DMG 已下载，请在下载目录手动打开','err');
+      return;
+    }
+    if(!confirm(`退出 Typeless 工具集并安装 v${d.version}？\n\n更新只替换程序文件，将保留 data 中的账号、快照、词库和配置。`)) return;
+    const r=await api('/api/toolkit-update/install',{method:'POST',body:'{}'});
+    if(r.status!=='OK'){ toast(r.msg||'准备更新失败','err'); return; }
+    TOOLKIT_UPDATE={...TOOLKIT_UPDATE,state:'installing',running:true}; renderToolkitUpdate();
+    toast('准备完成，正在退出并安装更新…','ok');
+    try{ window.chrome?.webview?.postMessage('toolkit-update:quit'); }
+    catch(e){ toast('请从托盘菜单退出工具集，更新程序会在退出后继续','err'); }
+    return;
+  }
+  const r=await api('/api/toolkit-update/download',{method:'POST',body:'{}'});
+  if(r.status!=='OK'){ toast(r.msg||'开始下载失败','err'); return; }
+  TOOLKIT_UPDATE=r.data||TOOLKIT_UPDATE; renderToolkitUpdate(); startToolkitUpdatePoll();
 }
 async function installOfficialUpdate(){
   const st=await api('/api/official-update'), d=st.data||{};
@@ -1437,6 +1579,7 @@ document.addEventListener('keydown',e=>{
   await refreshPaywallMaintenanceStatus();
   detectCurrent();
   refreshOfficialUpdate();
+  setTimeout(()=>refreshToolkitUpdate(true),1200);
   refreshDictionarySyncStatus();
 })();
 refreshOnboardingStatus();
@@ -1446,6 +1589,7 @@ setInterval(detectCurrent, 20000);
 setInterval(refreshDictionarySyncStatus, 12000);
 // 弹窗维护由后端执行；页面只读取状态并在需要用户同意时展示一次明确引导。
 setInterval(refreshPaywallMaintenanceStatus, 4000);
+setInterval(()=>refreshToolkitUpdate(false), 6*60*60*1000);
 window.addEventListener('focus',async()=>{
   const mask=document.getElementById('paywallPermissionMask');
   if(!mask?.classList.contains('on')||PAYWALL_FOCUS_RETRY_BUSY) return;

--- a/manager.js
+++ b/manager.js
@@ -12,6 +12,7 @@ const path = require('path');
 
 const C = require('./lib/common');
 const { installOfficialUpdate, officialUpdateStatus } = require('./lib/official-update');
+const { createToolkitUpdateController } = require('./lib/toolkit-update');
 const {
   config, ROOT, TYPELESS_EXE, USERDATA_DIR, ASAR_PATH, IS_MAC,
   readAccounts, writeAccounts, readCurrentUser,
@@ -41,6 +42,15 @@ const AUTO_SYNC_STARTUP_DELAY_MS = 6000;
 const AUTO_SYNC_DEBOUNCE_MS = 1200;
 const PAYWALL_MAINTENANCE_INTERVAL_MS = 15 * 60 * 1000;
 const PAYWALL_MAINTENANCE_STARTUP_DELAY_MS = 2500;
+const TOOLKIT_VERSION = require('./package.json').version;
+const toolkitUpdate = createToolkitUpdateController({
+  platform: IS_MAC ? 'darwin' : 'win32',
+  codeRoot: C.CODE_DIR,
+  dataRoot: ROOT,
+  currentVersion: TOOLKIT_VERSION,
+  parentPid: process.pid,
+  hostPid: Number(process.env.TYPELESS_TOOLKIT_HOST_PID || 0) || process.pid,
+});
 
 function createDictionarySyncController(syncFn, opts = {}) {
   const intervalMs = opts.intervalMs || AUTO_SYNC_INTERVAL_MS;
@@ -815,6 +825,40 @@ const server = http.createServer(async (req, res) => {
         data: outcome,
         msg: outcome.ok ? (outcome.result?.msg || outcome.status?.msg) : (outcome.error || outcome.status?.msg),
       });
+    }
+    // Typeless Toolkit 自身更新：所有平台可检查并下载经过 SHA-256 校验的发布包。
+    // Windows 在界面退出后由独立 helper 替换代码文件；macOS 只下载并打开 DMG，
+    // 不把 ad-hoc 签名版本伪装成可无感安装的自动更新。
+    if (m === 'GET' && p === '/api/toolkit-update') {
+      try {
+        const status = await toolkitUpdate.check();
+        return send(res, 200, { status: 'OK', data: status });
+      } catch (error) {
+        return send(res, 502, { status: 'FAIL', data: toolkitUpdate.status(), msg: error.message });
+      }
+    }
+    if (m === 'GET' && p === '/api/toolkit-update/status') {
+      return send(res, 200, { status: 'OK', data: toolkitUpdate.status() });
+    }
+    if (m === 'POST' && p === '/api/toolkit-update/download') {
+      await readBody(req);
+      if (toolkitUpdate.status().running) {
+        return send(res, 202, { status: 'OK', data: toolkitUpdate.status(), msg: '工具集更新包正在下载' });
+      }
+      toolkitUpdate.download().catch(error => log('[toolkit-update] 下载失败:', error.message));
+      return send(res, 202, { status: 'OK', data: toolkitUpdate.status(), msg: '已开始下载并校验工具集更新包' });
+    }
+    if (m === 'POST' && p === '/api/toolkit-update/install') {
+      await readBody(req);
+      try {
+        const result = toolkitUpdate.prepareWindowsInstall();
+        return send(res, 202, {
+          status: 'OK', data: result,
+          msg: `工具集 ${result.version} 已准备完成，退出当前窗口后将保留 data 目录并自动替换程序文件`,
+        });
+      } catch (error) {
+        return send(res, 409, { status: 'FAIL', data: toolkitUpdate.status(), msg: error.message });
+      }
     }
     // 查询 Typeless 官方 updater 已下载的更新包（macOS）
     if (m === 'GET' && p === '/api/official-update') {

--- a/manager.js
+++ b/manager.js
@@ -43,6 +43,8 @@ const AUTO_SYNC_DEBOUNCE_MS = 1200;
 const PAYWALL_MAINTENANCE_INTERVAL_MS = 15 * 60 * 1000;
 const PAYWALL_MAINTENANCE_STARTUP_DELAY_MS = 2500;
 const TOOLKIT_VERSION = require('./package.json').version;
+const toolkitBackendOwned = process.env.TYPELESS_TOOLKIT_BACKEND_OWNER === 'desktop-host' &&
+  path.resolve(process.env.TYPELESS_TOOLKIT_INSTALL_DIR || '') === path.resolve(C.CODE_DIR, '..');
 const toolkitUpdate = createToolkitUpdateController({
   platform: IS_MAC ? 'darwin' : 'win32',
   codeRoot: C.CODE_DIR,
@@ -50,6 +52,7 @@ const toolkitUpdate = createToolkitUpdateController({
   currentVersion: TOOLKIT_VERSION,
   parentPid: process.pid,
   hostPid: Number(process.env.TYPELESS_TOOLKIT_HOST_PID || 0) || process.pid,
+  backendOwned: toolkitBackendOwned,
 });
 
 function createDictionarySyncController(syncFn, opts = {}) {
@@ -1162,6 +1165,7 @@ function startServer() {
 server.on('close', () => {
   dictionarySync.stop();
   paywallMaintenance.stop();
+  toolkitUpdate.cleanupStaging();
 });
 
 if (require.main === module) {

--- a/manager.js
+++ b/manager.js
@@ -1101,7 +1101,10 @@ const server = http.createServer(async (req, res) => {
     }
     // 运行环境信息(排错用:平台、探测到的路径、凭据名)
     if (m === 'GET' && p === '/api/env') {
-      return send(res, 200, { status: 'OK', data: envInfo() });
+      return send(res, 200, {
+        status: 'OK',
+        data: { ...envInfo(), toolkit_version: TOOLKIT_VERSION, code_root: C.CODE_DIR },
+      });
     }
     // 一键备份(账号表 + 主词库,带时间戳)
     if (m === 'POST' && p === '/api/backup') {

--- a/manager.js
+++ b/manager.js
@@ -42,18 +42,6 @@ const AUTO_SYNC_STARTUP_DELAY_MS = 6000;
 const AUTO_SYNC_DEBOUNCE_MS = 1200;
 const PAYWALL_MAINTENANCE_INTERVAL_MS = 15 * 60 * 1000;
 const PAYWALL_MAINTENANCE_STARTUP_DELAY_MS = 2500;
-const TOOLKIT_VERSION = require('./package.json').version;
-const toolkitBackendOwned = process.env.TYPELESS_TOOLKIT_BACKEND_OWNER === 'desktop-host' &&
-  path.resolve(process.env.TYPELESS_TOOLKIT_INSTALL_DIR || '') === path.resolve(C.CODE_DIR, '..');
-const toolkitUpdate = createToolkitUpdateController({
-  platform: IS_MAC ? 'darwin' : 'win32',
-  codeRoot: C.CODE_DIR,
-  dataRoot: ROOT,
-  currentVersion: TOOLKIT_VERSION,
-  parentPid: process.pid,
-  hostPid: Number(process.env.TYPELESS_TOOLKIT_HOST_PID || 0) || process.pid,
-  backendOwned: toolkitBackendOwned,
-});
 
 function createDictionarySyncController(syncFn, opts = {}) {
   const intervalMs = opts.intervalMs || AUTO_SYNC_INTERVAL_MS;
@@ -540,6 +528,19 @@ const paywallMaintenance = createPaywallMaintenanceController(
     },
   }
 );
+
+const TOOLKIT_VERSION = require('./package.json').version;
+const toolkitBackendOwned = process.env.TYPELESS_TOOLKIT_BACKEND_OWNER === 'desktop-host' &&
+  path.resolve(process.env.TYPELESS_TOOLKIT_INSTALL_DIR || '') === path.resolve(C.CODE_DIR, '..');
+const toolkitUpdate = createToolkitUpdateController({
+  platform: IS_MAC ? 'darwin' : 'win32',
+  codeRoot: C.CODE_DIR,
+  dataRoot: ROOT,
+  currentVersion: TOOLKIT_VERSION,
+  parentPid: process.pid,
+  hostPid: Number(process.env.TYPELESS_TOOLKIT_HOST_PID || 0) || process.pid,
+  backendOwned: toolkitBackendOwned,
+});
 
 // ---------- HTTP ----------
 function send(res, code, obj) {
@@ -1168,8 +1169,9 @@ function startServer() {
 server.on('close', () => {
   dictionarySync.stop();
   paywallMaintenance.stop();
-  toolkitUpdate.cleanupStaging();
 });
+
+server.on('close', () => toolkitUpdate.cleanupStaging());
 
 if (require.main === module) {
   startServer().catch(error => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "node manager.js",
     "start:electron": "electron .",
     "sync": "node typeless-dict-sync.js",
-    "check": "node --check electron-main.js && node --check electron-preload.js && node --check manager.js && node --check typeless-dict-sync.js && node --check lib/common.js && node --check lib/platform.js && node --check lib/desktop-host.js && node --check lib/official-update.js && node --check scripts/prepare-mac-build.js && node --check scripts/hide-mac-build-app.js && node --check scripts/write-mac-checksum.js && node --check scripts/install-mac-build.js && node --check scripts/prepare-release-notes.js && node --test",
+    "check": "node --check electron-main.js && node --check electron-preload.js && node --check manager.js && node --check typeless-dict-sync.js && node --check lib/common.js && node --check lib/platform.js && node --check lib/desktop-host.js && node --check lib/official-update.js && node --check lib/toolkit-update.js && node --check scripts/prepare-mac-build.js && node --check scripts/hide-mac-build-app.js && node --check scripts/write-mac-checksum.js && node --check scripts/install-mac-build.js && node --check scripts/prepare-release-notes.js && node --test",
     "prepare:mac": "node scripts/prepare-mac-build.js",
     "hide:mac-build": "node scripts/hide-mac-build-app.js",
     "generate:icon:mac": "swift scripts/generate-mac-icon.swift",

--- a/test/toolkit-update.test.js
+++ b/test/toolkit-update.test.js
@@ -1,0 +1,136 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const {
+  assetNames,
+  compareVersions,
+  createToolkitUpdateController,
+  isSafeZipEntry,
+  parseSha256File,
+  releaseSummary,
+  resolveWindowsPayloadRoot,
+  writeWindowsUpdateHelper,
+} = require('../lib/toolkit-update');
+
+const HASH = 'a'.repeat(64);
+
+test('selects an update package that exactly matches the platform and Windows flavor', () => {
+  assert.deepEqual(assetNames('1.6.3', 'win32', 'portable'), {
+    archive: 'TypelessToolkit-v1.6.3-win-x64-portable.zip',
+    checksum: 'TypelessToolkit-v1.6.3-win-x64-portable.zip.sha256.txt',
+  });
+  assert.deepEqual(assetNames('1.6.3', 'darwin'), {
+    archive: 'Typeless-Toolkit-1.6.3-universal.dmg',
+    checksum: 'Typeless-Toolkit-1.6.3-universal.dmg.sha256.txt',
+  });
+  assert.equal(compareVersions('v1.6.10', '1.6.2'), 1);
+  assert.equal(compareVersions('1.6.2', '1.6.2'), 0);
+});
+
+test('requires a checksum that names the selected release asset', () => {
+  assert.equal(parseSha256File(`${HASH}  TypelessToolkit-v1.6.3-win-x64-lite.zip\n`, 'TypelessToolkit-v1.6.3-win-x64-lite.zip'), HASH);
+  assert.throws(() => parseSha256File(`${HASH}  other.zip\n`, 'expected.zip'), /不匹配/);
+  assert.throws(() => parseSha256File('not-a-hash expected.zip', 'expected.zip'), /格式无效/);
+});
+
+test('rejects archive paths that could escape the update staging directory', () => {
+  assert.equal(isSafeZipEntry('server/lib/toolkit-update.js'), true);
+  assert.equal(isSafeZipEntry('../data/accounts.json'), false);
+  assert.equal(isSafeZipEntry('/Windows/System32/file'), false);
+  assert.equal(isSafeZipEntry('C:\\Windows\\System32\\file'), false);
+});
+
+test('reports an update only when release assets and checksums are both present', () => {
+  const names = assetNames('1.6.3', 'win32', 'portable');
+  const release = {
+    html_url: 'https://example.invalid/releases/v1.6.3',
+    body: '## 新功能',
+    assets: [
+      { name: names.archive, browser_download_url: 'https://example.invalid/app.zip', size: 123 },
+      { name: names.checksum, browser_download_url: 'https://example.invalid/app.sha256.txt' },
+    ],
+  };
+  const state = releaseSummary(release, '1.6.3', '1.6.2', 'win32', 'portable');
+  assert.equal(state.available, true);
+  assert.equal(state.error, null);
+  assert.equal(state.asset.name, names.archive);
+});
+
+test('checks the GitHub latest-release response without downloading an asset', async () => {
+  const names = assetNames('1.6.3', 'win32', 'portable');
+  const controller = createToolkitUpdateController({
+    platform: 'win32', currentVersion: '1.6.2', flavor: 'portable',
+    fetchFn: async url => {
+      assert.match(url, /\/releases\/latest$/);
+      return {
+        ok: true,
+        json: async () => ({
+          tag_name: 'v1.6.3', html_url: 'https://example.invalid/r', body: 'notes', assets: [
+            { name: names.archive, browser_download_url: 'https://example.invalid/app.zip' },
+            { name: names.checksum, browser_download_url: 'https://example.invalid/app.sha256.txt' },
+          ],
+        }),
+      };
+    },
+  });
+  const state = await controller.check();
+  assert.equal(state.state, 'available');
+  assert.equal(state.available, true);
+  assert.equal(state.version, '1.6.3');
+});
+
+test('downloads an update to staging and verifies SHA-256 before exposing it', async t => {
+  const version = '1.6.3';
+  const names = assetNames(version, 'darwin');
+  const payload = Buffer.from('verified-dmg-fixture');
+  const checksum = crypto.createHash('sha256').update(payload).digest('hex');
+  const controller = createToolkitUpdateController({
+    platform: 'darwin', currentVersion: '1.6.2',
+    fetchFn: async url => {
+      if (url.includes('/releases/latest')) return {
+        ok: true,
+        json: async () => ({ tag_name: `v${version}`, body: 'notes', assets: [
+          { name: names.archive, browser_download_url: 'https://example.invalid/toolkit.dmg' },
+          { name: names.checksum, browser_download_url: 'https://example.invalid/toolkit.dmg.sha256.txt' },
+        ] }),
+      };
+      if (url.endsWith('.sha256.txt')) return { ok: true, text: async () => `${checksum}  ${names.archive}\n` };
+      return new Response(payload, { status: 200, headers: { 'content-length': String(payload.length) } });
+    },
+  });
+  t.after(() => {
+    const download = controller.status().download_path;
+    if (download) fs.rmSync(path.dirname(download), { recursive: true, force: true });
+  });
+  await controller.check();
+  const state = await controller.download();
+  assert.equal(state.state, 'downloaded');
+  assert.equal(fs.readFileSync(state.download_path).toString(), payload.toString());
+});
+
+test('accepts the single top-level directory produced by the public Windows ZIP', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'toolkit-payload-test-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const payload = path.join(root, 'TypelessToolkit-v1.6.3-win-x64-portable');
+  fs.mkdirSync(path.join(payload, 'server'), { recursive: true });
+  fs.writeFileSync(path.join(payload, 'TypelessToolkit.exe'), 'launcher');
+  fs.writeFileSync(path.join(payload, 'server', 'manager.js'), 'server');
+  assert.equal(resolveWindowsPayloadRoot(root), payload);
+});
+
+test('Windows replacement helper preserves data and never copies release data over it', t => {
+  const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'toolkit-helper-test-'));
+  t.after(() => fs.rmSync(stage, { recursive: true, force: true }));
+  const helper = writeWindowsUpdateHelper(stage);
+  const source = fs.readFileSync(helper, 'utf8');
+  assert.match(source, /\[int\]\$HostPid/);
+  assert.match(source, /Get-Process -Id \$HostPid/);
+  assert.match(source, /\[string\]\$StageDir/);
+  assert.match(source, /rmdir \/s \/q/);
+  assert.match(source, /Name -ne 'data'/);
+  assert.match(source, /Where-Object \{ \$_\.Name -ne 'data' \}/);
+});

--- a/test/toolkit-update.test.js
+++ b/test/toolkit-update.test.js
@@ -96,6 +96,7 @@ test('checks the GitHub latest-release response without downloading an asset', a
   assert.equal(state.state, 'available');
   assert.equal(state.available, true);
   assert.equal(state.version, '1.6.3');
+  assert.equal(state.running, false);
 });
 
 test('reused Windows backend is explicitly manual-update only', async () => {

--- a/test/toolkit-update.test.js
+++ b/test/toolkit-update.test.js
@@ -9,10 +9,15 @@ const {
   assetNames,
   compareVersions,
   createToolkitUpdateController,
+  downloadToFile,
+  installationInfo,
   isSafeZipEntry,
   parseSha256File,
   releaseSummary,
   resolveWindowsPayloadRoot,
+  validateWindowsPayload,
+  validateZipEntryMetadata,
+  validateZipMetadata,
   writeWindowsUpdateHelper,
 } = require('../lib/toolkit-update');
 
@@ -27,6 +32,7 @@ test('selects an update package that exactly matches the platform and Windows fl
     archive: 'Typeless-Toolkit-1.6.3-universal.dmg',
     checksum: 'Typeless-Toolkit-1.6.3-universal.dmg.sha256.txt',
   });
+  assert.equal(assetNames('1.6.3', 'win32', 'unknown'), null);
   assert.equal(compareVersions('v1.6.10', '1.6.2'), 1);
   assert.equal(compareVersions('1.6.2', '1.6.2'), 0);
 });
@@ -42,6 +48,15 @@ test('rejects archive paths that could escape the update staging directory', () 
   assert.equal(isSafeZipEntry('../data/accounts.json'), false);
   assert.equal(isSafeZipEntry('/Windows/System32/file'), false);
   assert.equal(isSafeZipEntry('C:\\Windows\\System32\\file'), false);
+});
+
+test('rejects oversized or suspicious ZIP entry metadata before extraction', () => {
+  assert.doesNotThrow(() => validateZipEntryMetadata({ name: 'server/manager.js', length: 100, compressedLength: 50 }));
+  assert.throws(() => validateZipEntryMetadata({ name: '../data/accounts.json', length: 1, compressedLength: 1 }), /不安全路径/);
+  assert.throws(() => validateZipEntryMetadata({ name: 'big.bin', length: 513 * 1024 * 1024, compressedLength: 1 }), /大小超出上限/);
+  assert.throws(() => validateZipEntryMetadata({ name: 'bomb.txt', length: 1000, compressedLength: 1 }), /压缩比例异常/);
+  assert.throws(() => validateZipMetadata(Array.from({ length: 5001 }, (_, index) => ({ name: `file-${index}`, length: 0, compressedLength: 0 }))), /文件数量超出上限/);
+  assert.throws(() => validateZipMetadata(Array.from({ length: 5 }, (_, index) => ({ name: `large-${index}.bin`, length: 512 * 1024 * 1024, compressedLength: 512 * 1024 * 1024 }))), /解压总大小超出上限/);
 });
 
 test('reports an update only when release assets and checksums are both present', () => {
@@ -63,7 +78,7 @@ test('reports an update only when release assets and checksums are both present'
 test('checks the GitHub latest-release response without downloading an asset', async () => {
   const names = assetNames('1.6.3', 'win32', 'portable');
   const controller = createToolkitUpdateController({
-    platform: 'win32', currentVersion: '1.6.2', flavor: 'portable',
+    platform: 'win32', currentVersion: '1.6.2', flavor: 'portable', backendOwned: true,
     fetchFn: async url => {
       assert.match(url, /\/releases\/latest$/);
       return {
@@ -81,6 +96,21 @@ test('checks the GitHub latest-release response without downloading an asset', a
   assert.equal(state.state, 'available');
   assert.equal(state.available, true);
   assert.equal(state.version, '1.6.3');
+});
+
+test('reused Windows backend is explicitly manual-update only', async () => {
+  const names = assetNames('1.6.3', 'win32', 'portable');
+  const controller = createToolkitUpdateController({
+    platform: 'win32', currentVersion: '1.6.2', flavor: 'portable', backendOwned: false,
+    fetchFn: async () => ({ ok: true, json: async () => ({ tag_name: 'v1.6.3', assets: [
+      { name: names.archive, browser_download_url: 'https://example.invalid/app.zip' },
+      { name: names.checksum, browser_download_url: 'https://example.invalid/app.sha256.txt' },
+    ] }) }),
+  });
+  const state = await controller.check();
+  assert.equal(state.state, 'manual-only');
+  assert.equal(state.update.manual_only, true);
+  assert.match(state.update.error, /复用了已有本地服务/);
 });
 
 test('downloads an update to staging and verifies SHA-256 before exposing it', async t => {
@@ -110,6 +140,17 @@ test('downloads an update to staging and verifies SHA-256 before exposing it', a
   const state = await controller.download();
   assert.equal(state.state, 'downloaded');
   assert.equal(fs.readFileSync(state.download_path).toString(), payload.toString());
+  const stage = state.stage_dir;
+  controller.cleanupStaging();
+  assert.equal(fs.existsSync(stage), false);
+});
+
+test('macOS IPC only opens a regular DMG in the exact updater staging directory', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'electron-main.js'), 'utf8');
+  assert.match(source, /fs\.lstatSync\(target\)/);
+  assert.match(source, /fs\.realpathSync\(os\.tmpdir\(\)\)/);
+  assert.match(source, /path\.dirname\(realStage\) !== realTemp/);
+  assert.match(source, /path\.basename\(realStage\)\.startsWith\('typeless-toolkit-update-'\)/);
 });
 
 test('accepts the single top-level directory produced by the public Windows ZIP', t => {
@@ -122,7 +163,55 @@ test('accepts the single top-level directory produced by the public Windows ZIP'
   assert.equal(resolveWindowsPayloadRoot(root), payload);
 });
 
-test('Windows replacement helper preserves data and never copies release data over it', t => {
+function makeWindowsInstall(root, version = '1.6.3', edition = 'portable') {
+  fs.mkdirSync(path.join(root, 'server'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'TypelessToolkit.exe'), 'launcher');
+  fs.writeFileSync(path.join(root, 'server', 'manager.js'), 'server');
+  fs.writeFileSync(path.join(root, 'server', 'package.json'), JSON.stringify({ version }));
+  if (edition === 'portable') {
+    fs.mkdirSync(path.join(root, 'runtime'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'runtime', 'node.exe'), 'node');
+  }
+}
+
+test('requires a standard Windows release root and derives its edition from the runtime', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'toolkit-install-test-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  makeWindowsInstall(root);
+  assert.deepEqual(installationInfo(path.join(root, 'server'), path.join(root, 'data')), {
+    ok: true, install_dir: root, edition: 'portable', error: null,
+  });
+  assert.equal(installationInfo(root, path.join(root, 'data')).ok, false);
+  fs.rmSync(path.join(root, 'runtime'), { recursive: true });
+  assert.equal(installationInfo(path.join(root, 'server'), path.join(root, 'data')).edition, 'lite');
+});
+
+test('requires the target version and matching Portable/Lite payload structure', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'toolkit-payload-validation-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  makeWindowsInstall(root, '1.6.3', 'portable');
+  assert.doesNotThrow(() => validateWindowsPayload(root, '1.6.3', 'portable'));
+  assert.throws(() => validateWindowsPayload(root, '1.6.4', 'portable'), /版本与目标/);
+  assert.throws(() => validateWindowsPayload(root, '1.6.3', 'lite'), /包含内置 Node/);
+  fs.rmSync(path.join(root, 'runtime'), { recursive: true });
+  assert.throws(() => validateWindowsPayload(root, '1.6.3', 'portable'), /缺少内置 Node/);
+});
+
+test('removes a partially downloaded file when its stream fails', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'toolkit-download-test-'));
+  const output = path.join(dir, 'failed.bin');
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const body = new ReadableStream({
+    start(controller) { controller.enqueue(Buffer.from('partial')); controller.error(new Error('network lost')); },
+  });
+  await assert.rejects(downloadToFile('https://example.invalid/file', output, {
+    fetchFn: async () => ({ ok: true, headers: { get: () => null }, body }),
+  }), /network lost/);
+  assert.equal(fs.existsSync(output), false);
+});
+
+test('Windows replacement helper uses one temporary rollback and never copies release data over it', t => {
   const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'toolkit-helper-test-'));
   t.after(() => fs.rmSync(stage, { recursive: true, force: true }));
   const helper = writeWindowsUpdateHelper(stage);
@@ -130,6 +219,9 @@ test('Windows replacement helper preserves data and never copies release data ov
   assert.match(source, /\[int\]\$HostPid/);
   assert.match(source, /Get-Process -Id \$HostPid/);
   assert.match(source, /\[string\]\$StageDir/);
+  assert.match(source, /\[string\]\$RollbackDir/);
+  assert.match(source, /Move-Item -LiteralPath/);
+  assert.match(source, /Write-Result 'rolled-back'/);
   assert.match(source, /rmdir \/s \/q/);
   assert.match(source, /Name -ne 'data'/);
   assert.match(source, /Where-Object \{ \$_\.Name -ne 'data' \}/);

--- a/test/toolkit-update.test.js
+++ b/test/toolkit-update.test.js
@@ -221,6 +221,10 @@ test('Windows replacement helper uses one temporary rollback and never copies re
   assert.match(source, /\[string\]\$StageDir/);
   assert.match(source, /\[string\]\$RollbackDir/);
   assert.match(source, /Move-Item -LiteralPath/);
+  assert.match(source, /\$oldMoveCompleted = \$false/);
+  assert.match(source, /\$replacementStarted = \$false/);
+  assert.match(source, /\$oldMoveCompleted = \$true\s+\$replacementStarted = \$true/);
+  assert.match(source, /if \(\$oldMoveCompleted -and \$replacementStarted\) \{\s+Get-ChildItem -LiteralPath \$install/);
   assert.match(source, /Write-Result 'rolled-back'/);
   assert.match(source, /rmdir \/s \/q/);
   assert.match(source, /Name -ne 'data'/);

--- a/test/toolkit-update.test.js
+++ b/test/toolkit-update.test.js
@@ -220,13 +220,31 @@ test('Windows replacement helper uses one temporary rollback and never copies re
   assert.match(source, /Get-Process -Id \$HostPid/);
   assert.match(source, /\[string\]\$StageDir/);
   assert.match(source, /\[string\]\$RollbackDir/);
+  assert.match(source, /\[string\]\$ReadyPath/);
   assert.match(source, /Move-Item -LiteralPath/);
   assert.match(source, /\$oldMoveCompleted = \$false/);
   assert.match(source, /\$replacementStarted = \$false/);
   assert.match(source, /\$oldMoveCompleted = \$true\s+\$replacementStarted = \$true/);
   assert.match(source, /if \(\$oldMoveCompleted -and \$replacementStarted\) \{\s+Get-ChildItem -LiteralPath \$install/);
+  assert.match(source, /Start-Process -FilePath \$RestartExe .*--toolkit-update-ready/);
+  assert.match(source, /while \(!\(Test-Path -LiteralPath \$ready\)\)/);
+  assert.match(source, /Get-Content -LiteralPath \$ready -Raw/);
+  assert.doesNotMatch(source, /Start-Sleep -Seconds 4/);
   assert.match(source, /Write-Result 'rolled-back'/);
   assert.match(source, /rmdir \/s \/q/);
   assert.match(source, /Name -ne 'data'/);
   assert.match(source, /Where-Object \{ \$_\.Name -ne 'data' \}/);
+});
+
+test('desktop ready handshake verifies the running backend version before writing a stage marker', () => {
+  const manager = fs.readFileSync(path.join(__dirname, '..', 'manager.js'), 'utf8');
+  const desktop = fs.readFileSync(path.join(__dirname, '..', 'main.cs'), 'utf8');
+  const updater = fs.readFileSync(path.join(__dirname, '..', 'lib', 'toolkit-update.js'), 'utf8');
+  assert.match(manager, /toolkit_version: TOOLKIT_VERSION/);
+  assert.match(manager, /code_root: C\.CODE_DIR/);
+  assert.match(desktop, /--toolkit-update-ready/);
+  assert.match(desktop, /SignalUpdateReady\(\)/);
+  assert.match(desktop, /ProbeToolkit\(updateTargetVersion\)/);
+  assert.match(desktop, /File\.WriteAllText\(updateReadyPath, updateTargetVersion/);
+  assert.match(updater, /fs\.rmSync\(extractionDir, \{ recursive: true, force: true \}\)/);
 });


### PR DESCRIPTION
## 目标

增加工具集内的版本检查与引导更新；保持 PR 打开，供维护者审查。

## 当前行为

- Windows：检查 GitHub Release、下载与 SHA-256 校验当前 Portable/Lite ZIP；确认退出后由临时更新助手替换程序文件并重启。
- macOS：仅下载并校验 Universal DMG，然后在 Finder 打开；不会宣称静默覆盖 ad-hoc 签名 App。
- “安装 Typeless 官方更新”仍是独立的 macOS 功能，不会与 Toolkit 更新混用。

## 安全与数据边界

- Windows 仅在标准 Release 目录、并且当前桌面宿主实际拥有后端时允许自动替换；复用已有本地服务时明确转为手动更新。
- `data/` 从不移动、复制或覆盖。更新期间至多使用一个同盘临时的非 `data/` rollback 目录：新版通过真实就绪确认后立即删除；复制、校验、启动或确认失败时原位恢复旧程序后立即删除。
- 新版启动时携带一次性 stage 内 ready marker 路径和目标版本；只有 `/api/env` 确认服务身份及 `toolkit_version` 与目标一致后，桌面宿主才写 marker。helper 收到该 marker 后才完成更新；marker 随 stage 清理，不留历史。
- 下载使用流式错误处理与 SHA-256；ZIP 解压前限制路径、条目数、解压总量、单文件量和压缩比；替换前验证包版本、服务器结构及 Portable/Lite Node 完整性。解压或 payload 校验失败会清理 payload，但保留已校验 ZIP 以便重试。
- macOS IPC 仅接受真实临时 staging 目录内的普通、非符号链接目标 DMG。

## 验证

- `npm run check`：89 tests passed
- `git diff --check`：passed
- `npm run build:mac`：arm64 DMG built successfully
- 管理界面 1200px、880px 宽度验收：无横向溢出，工具栏按钮不裁切
- 更新检查完成后状态恢复为 `running: false`，按钮不会停留在“工具集更新中…”

## 已知验证边界

当前在 macOS 开发机完成了 JS、macOS 打包与界面回归验证；Windows 的真实 Release 目录更新/回退 E2E 需要在 Windows 上执行，未在此 PR 中虚报为已完成。
